### PR TITLE
Pass source model to DcCompat in ContainerOnCopyCallbackListener

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ContainerOnCopyCallbackListener.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ContainerOnCopyCallbackListener.php
@@ -33,6 +33,6 @@ class ContainerOnCopyCallbackListener extends AbstractCallbackListener
 	 */
 	public function getArgs($event)
 	{
-		return array($event->getModel()->getId(), new DcCompat($event->getEnvironment(), $event->getModel()));
+		return array($event->getModel()->getId(), new DcCompat($event->getEnvironment(), $event->getSourceModel()));
 	}
 }


### PR DESCRIPTION
DC_Table::copy does not update the activeRecord
