### PR TITLE
Fix href attribute passed to legacy callback

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ModelOperationButtonCallbackListener.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ModelOperationButtonCallbackListener.php
@@ -87,12 +87,6 @@ class ModelOperationButtonCallbackListener extends AbstractReturningCallbackList
 			$strHref .= sprintf('&%s=%s', $key, $value);
 		}
 
-		// add action as well, only if no module key is given
-		if(!isset($arrParameters['key']))
-		{
-			$strHref .= sprintf('&%s=%s', 'act', $command->getName());
-		}
-
 		return $strHref;
 	}
 


### PR DESCRIPTION
Legacy callbacks are using the simplyfied href, without `contao/main.php?do=...`. Using a legacy callback break the link at the moment because the request part is added twice.

Instead of passing the built href to the callback, the parameters should be used building the href again. This PR provides an implementation for this.
