### PR TITLE
Fix incompatibility with Contao 3.5

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -15,4 +15,6 @@ mapping:
   "Andreas Nölke <zero@brothers-project.de>":
     - "Zeromax <zero@brothers-project.de>"
     - "Zeromax <zero@prothers-project.de>"
-  "David Molineus <mail@netzmacht.de>": "netzmacht <mail@netzmacht.de>"
+  "David Molineus <david.molineus@netzmacht.de>":
+    - "netzmacht <mail@netzmacht.de>"
+    - "David Molineus <mail@netzmacht.de>":

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "contao/core": ">=3.2,<3.5",
+        "contao/core": ">=3.2,<3.6",
         "contao-community-alliance/composer-plugin": "~2.0",
         "contao-community-alliance/event-dispatcher": "~1.3",
         "contao-community-alliance/translator": "~1.0",

--- a/src/ContaoCommunityAlliance/DcGeneral/DC_General.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/DC_General.php
@@ -373,4 +373,30 @@ class DC_General extends \DataContainer implements DataContainerInterface
     {
         return $this->callAction();
     }
+
+    /**
+     * Do not use.
+     *
+     * @deprecated Only here as requirement of \DataContainer
+     *
+     * @return void
+     * @throws DcGeneralRuntimeException
+     */
+    public function getPalette()
+    {
+        throw new DcGeneralRuntimeException('DC General does not support $dc->getPalette().');
+    }
+
+    /**
+     * Do not use.
+     *
+     * @deprecated Only here as requirement of \DataContainer
+     *
+     * @return void
+     * @throws DcGeneralRuntimeException
+     */
+    protected function save($varValue)
+    {
+        throw new DcGeneralRuntimeException('DC General does not support $dc->save.');
+    }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/DC_General.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/DC_General.php
@@ -10,6 +10,7 @@
  * @author     David Maack <david.maack@arcor.de>
  * @author     Patrick Kahl <kahl.patrick@googlemail.com>
  * @author     Simon Kusterer <simon@soped.com>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -380,7 +381,7 @@ class DC_General extends \DataContainer implements DataContainerInterface
      * @deprecated Only here as requirement of \DataContainer
      *
      * @return void
-     * @throws DcGeneralRuntimeException
+     * @throws DcGeneralRuntimeException Throws exception because method is not supported.
      */
     public function getPalette()
     {
@@ -393,7 +394,7 @@ class DC_General extends \DataContainer implements DataContainerInterface
      * @deprecated Only here as requirement of \DataContainer
      *
      * @return void
-     * @throws DcGeneralRuntimeException
+     * @throws DcGeneralRuntimeException Throws exception because method is not supported.
      */
     protected function save($varValue)
     {


### PR DESCRIPTION
Contao 3.5 changed the required methods of \DataContainer by defining them as abstrac (See #106). This pull request adds them to `\Dc_General` by throwing an exception when calling them. The DCG does not the calls as far as I see.