### PR TITLE
fix for page tree select

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/Ajax3X.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/Ajax3X.php
@@ -60,7 +60,7 @@ class Ajax3X extends Ajax
         // Process input and update changed properties.
         $treeType      = substr($property->getWidgetType(), 0, 4);
         $propertyValue = $this->getTreeValue($treeType, $propertyValue);
-        if ($treeType == 'file') {
+        if (($treeType == 'file') || ($treeType == 'page')) {
             $extra = $property->getExtra();
             if (is_array($propertyValue) && !isset($extra['multiple'])) {
                 $propertyValue = $propertyValue[0];


### PR DESCRIPTION
when you select an page in the popup window, you becomes the value as array