### PR TITLE
Hide first breadcrumb separater

### DIFF
--- a/contao/html/css/generalBreadcrumb.css
+++ b/contao/html/css/generalBreadcrumb.css
@@ -1,1 +1,1 @@
-@media screen,projection{#tl_breadcrumb{padding-top:4px;}#tl_breadcrumb li:before{content:">";padding-right: 5px;}#tl_breadcrumb li:first-child:before{content:"";}}
+@media screen, projection{#tl_breadcrumb{padding-top:4px}#tl_breadcrumb li:before{content:">";padding-right:5px}#tl_breadcrumb li:first-child:before{display:none}}

--- a/contao/html/sass/generalBreadcrumb.scss
+++ b/contao/html/sass/generalBreadcrumb.scss
@@ -17,6 +17,6 @@
   }
 
   #tl_breadcrumb li:first-child:before {
-    content: "";
+    display: none;
   }
 }


### PR DESCRIPTION
Hide first breadcrumb separater as an empty content causes to break icon and text (at least in Google Chrome).