### PR TITLE
Fix manual sorting

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
@@ -5,6 +5,7 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
@@ -1003,7 +1003,7 @@ class LegacyDcaDataDefinitionBuilder extends DcaReadingDataDefinitionBuilder
      * Add filter elements to the panel.
      *
      * @param PanelRowInterface $row The row to which the element shall get added to.
-     *<
+     *
      * @return void
      */
     protected function parsePanelFilter(PanelRowInterface $row)

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
@@ -865,6 +865,11 @@ class LegacyDcaDataDefinitionBuilder extends DcaReadingDataDefinitionBuilder
             $information->setGroupingLength($propInfo['length']);
         }
 
+        // Special case for field named "sorting" in Contao.
+        if ($propName === 'sorting') {
+            $information->setManualSorting();
+        }
+
         $flag = empty($propInfo['flag']) ? $this->getFromDca('list/sorting/flag') : $propInfo['flag'];
         $this->evalFlag($information, $flag);
     }
@@ -997,7 +1002,7 @@ class LegacyDcaDataDefinitionBuilder extends DcaReadingDataDefinitionBuilder
      * Add filter elements to the panel.
      *
      * @param PanelRowInterface $row The row to which the element shall get added to.
-     *
+     *<
      * @return void
      */
     protected function parsePanelFilter(PanelRowInterface $row)

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
@@ -505,6 +505,10 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
             : null;
         $items         = array();
 
+        $panel      = $this->getPanel();
+        $baseConfig = $environment->getBaseConfigRegistry()->getBaseConfig();
+        $panel->initialize($baseConfig);
+
         $models = $controller->applyClipboardActions($source, $after, $into, $parentModelId, null, $items);
 
         if (!$source) {


### PR DESCRIPTION
The manual sorting did not work because the manual sorting attribute was not set for the group and sorting definition (Fix #115).