### PR TITLE
Do not use default sorting when panel initializes it.

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
@@ -6,6 +6,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -52,7 +53,15 @@ class ListView extends BaseView
         $dataProvider  = $environment->getDataProvider();
         $dataConfig    = $environment->getBaseConfigRegistry()->getBaseConfig();
 
+        // Store default sorting start initializing the panel with an empty sorting.
+        $sorting = $dataConfig->getSorting();
+        $dataConfig->setSorting(array());
         $this->getPanel()->initialize($dataConfig);
+
+        // Restore default sorting if panel did not set any.
+        if ($sorting && !$dataConfig->getSorting()) {
+            $dataConfig->setSorting($sorting);
+        }
 
         // Initialize sorting if not present yet.
         if (!$dataConfig->getSorting() && $listingConfig->getGroupAndSortingDefinition()->hasDefault()) {

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
@@ -53,29 +53,9 @@ class ListView extends BaseView
         $dataProvider  = $environment->getDataProvider();
         $dataConfig    = $environment->getBaseConfigRegistry()->getBaseConfig();
 
-        // Store default sorting start initializing the panel with an empty sorting.
-        $sorting = $dataConfig->getSorting();
-        $dataConfig->setSorting(array());
-        $this->getPanel()->initialize($dataConfig);
+        ViewHelpers::initializeSorting($this->getPanel(), $dataConfig, $listingConfig);
 
-        // Restore default sorting if panel did not set any.
-        if ($sorting && !$dataConfig->getSorting()) {
-            $dataConfig->setSorting($sorting);
-        }
-
-        // Initialize sorting if not present yet.
-        if (!$dataConfig->getSorting() && $listingConfig->getGroupAndSortingDefinition()->hasDefault()) {
-            $newSorting = array();
-            foreach ($listingConfig->getGroupAndSortingDefinition()->getDefault() as $information) {
-                /** @var GroupAndSortingInformationInterface $information */
-                $newSorting[$information->getProperty()] = strtoupper($information->getSortingMode());
-            }
-            $dataConfig->setSorting($newSorting);
-        }
-
-        $objCollection = $dataProvider->fetchAll($dataConfig);
-
-        return $objCollection;
+        return $dataProvider->fetchAll($dataConfig);
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
@@ -61,29 +61,9 @@ class ParentView extends BaseView
         $childConfig   = $environment->getBaseConfigRegistry()->getBaseConfig();
         $listingConfig = $this->getViewSection()->getListingConfig();
 
-        // Store default sorting start initializing the panel with an empty sorting.
-        $sorting = $childConfig->getSorting();
-        $childConfig->setSorting(array());
-        $this->getPanel()->initialize($childConfig);
+        ViewHelpers::initializeSorting($this->getPanel(), $childConfig, $listingConfig);
 
-        // Restore default sorting if panel did not set any.
-        if ($sorting && !$childConfig->getSorting()) {
-            $childConfig->setSorting($sorting);
-        }
-
-        // Initialize sorting if not present yet.
-        if (!$childConfig->getSorting() && $listingConfig->getGroupAndSortingDefinition()->hasDefault()) {
-            $newSorting = array();
-            foreach ($listingConfig->getGroupAndSortingDefinition()->getDefault() as $information) {
-                /** @var GroupAndSortingInformationInterface $information */
-                $newSorting[$information->getProperty()] = strtoupper($information->getSortingMode());
-            }
-            $childConfig->setSorting($newSorting);
-        }
-
-        $objChildCollection = $dataProvider->fetchAll($childConfig);
-
-        return $objChildCollection;
+        return $dataProvider->fetchAll($childConfig);
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
@@ -6,6 +6,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -60,7 +61,15 @@ class ParentView extends BaseView
         $childConfig   = $environment->getBaseConfigRegistry()->getBaseConfig();
         $listingConfig = $this->getViewSection()->getListingConfig();
 
+        // Store default sorting start initializing the panel with an empty sorting.
+        $sorting = $childConfig->getSorting();
+        $childConfig->setSorting(array());
         $this->getPanel()->initialize($childConfig);
+
+        // Restore default sorting if panel did not set any.
+        if ($sorting && !$childConfig->getSorting()) {
+            $childConfig->setSorting($sorting);
+        }
 
         // Initialize sorting if not present yet.
         if (!$childConfig->getSorting() && $listingConfig->getGroupAndSortingDefinition()->hasDefault()) {


### PR DESCRIPTION
The sorting panel did not have any affects if a default sorting is defined. It would be added as additional sortings. This pull request starts the panel initialization with an empty sorting definition and will fallback to the defualt one.