### PR TITLE
Fix: Only first letter of label shown

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
@@ -153,7 +153,7 @@ class ListView extends BaseView
 
                 $arrTableHead[] = array(
                     'class'   => 'tl_folder_tlist col_' . $f . ((in_array($f, $sortingColumns)) ? ' ordered_by' : ''),
-                    'content' => $label[0]
+                    'content' => $label
                 );
             }
 


### PR DESCRIPTION
[0] does not make sense here.  $label is a string. The description is in getDescription() instead

To verify, let \ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\DefaultListingConfig::getShowColumns return true