### PR TITLE
Introduce a generic model id.

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
@@ -810,7 +810,7 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
         if ($serializedPid = $environment->getInputProvider()->getParameter('pid')) {
             $pid = IdSerializer::fromSerialized($serializedPid);
         } else {
-            $pid = new IdSerializer();
+            $pid = null;
         }
 
         if (!$basicDefinition->isCreatable()) {
@@ -839,7 +839,7 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
         ) {
             $parameters['act'] = 'edit';
             // Add new button.
-            if ($pid->getDataProviderName() && $pid->getId()) {
+            if ($pid) {
                 $parameters['pid'] = $pid->getSerialized();
             }
         } elseif (
@@ -860,7 +860,7 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
 
             $parameters['act'] = 'create';
 
-            if ($pid->getDataProviderName() && $pid->getId()) {
+            if ($pid) {
                 $parameters['pid'] = $pid->getSerialized();
             }
         }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
@@ -5,6 +5,7 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
@@ -13,6 +13,8 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
+
 /**
  * The class IdSerializer provides handy methods to serialize and un-serialize model ids including the data provider
  * name into a string.

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
@@ -5,7 +5,6 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
- * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -13,7 +12,9 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
-use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
 
 /**
  * The class IdSerializer provides handy methods to serialize and un-serialize model ids including the data provider
@@ -23,8 +24,22 @@ use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
  *
  * @package DcGeneral\Contao\View\Contao2BackendView
  */
-class IdSerializer extends ModelId
+class IdSerializer implements ModelIdInterface
 {
+    /**
+     * The data provider name.
+     *
+     * @var string
+     */
+    protected $dataProviderName;
+
+    /**
+     * The id of the model.
+     *
+     * @var mixed
+     */
+    protected $modelId;
+
     /**
      * Set the data provider name.
      *
@@ -37,6 +52,16 @@ class IdSerializer extends ModelId
         $this->dataProviderName = $dataProviderName;
 
         return $this;
+    }
+
+    /**
+     * Retrieve the data provider name.
+     *
+     * @return string
+     */
+    public function getDataProviderName()
+    {
+        return $this->dataProviderName;
     }
 
     /**
@@ -54,6 +79,96 @@ class IdSerializer extends ModelId
     }
 
     /**
+     * Retrieve the id.
+     *
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->modelId;
+    }
+
+    /**
+     * Create an instance from the passed values.
+     *
+     * @param string $dataProviderName The data provider name.
+     *
+     * @param mixed  $modelId          The id.
+     *
+     * @return IdSerializer
+     */
+    public static function fromValues($dataProviderName, $modelId)
+    {
+        $instance = new IdSerializer();
+
+        $instance
+            ->setId($modelId)
+            ->setDataProviderName($dataProviderName);
+
+        return $instance;
+    }
+
+    /**
+     * Create an instance from a model.
+     *
+     * @param ModelInterface $model The model.
+     *
+     * @return IdSerializer
+     */
+    public static function fromModel(ModelInterface $model)
+    {
+        return self::fromValues($model->getProviderName(), $model->getId());
+    }
+
+    /**
+     * Create an instance from an serialized id.
+     *
+     * @param string $serialized The id.
+     *
+     * @return IdSerializer
+     *
+     * @throws DcGeneralRuntimeException When invalid data is encountered.
+     */
+    public static function fromSerialized($serialized)
+    {
+        $instance = new IdSerializer();
+
+        $serialized = rawurldecode($serialized);
+        $serialized = html_entity_decode($serialized, ENT_QUOTES, 'UTF-8');
+
+        $chunks = explode('::', $serialized);
+
+        if (count($chunks) !== 2) {
+            throw new DcGeneralRuntimeException('Unparsable encoded id value: ' . var_export($serialized, true));
+        }
+
+        $instance->setDataProviderName($chunks[0]);
+
+        if (is_numeric($chunks[1])) {
+            return $instance->setId($chunks[1]);
+        }
+
+        $decodedSource = base64_decode($chunks[1]);
+        $decodedJson   = json_decode($decodedSource, true);
+
+        return $instance->setId($decodedJson ?: $decodedSource);
+    }
+
+    /**
+     * Serialize the id.
+     *
+     * @return string
+     */
+    public function getSerialized()
+    {
+        if (is_numeric($this->modelId)) {
+            return sprintf('%s::%s', $this->dataProviderName, $this->modelId);
+        }
+
+        return sprintf('%s::%s', $this->dataProviderName, base64_encode(json_encode($this->modelId)));
+    }
+
+    /**
      * Determine if both, data provider name and id are set and non empty.
      *
      * @return bool
@@ -61,5 +176,27 @@ class IdSerializer extends ModelId
     public function isValid()
     {
         return !(empty($this->modelId) || empty($this->dataProviderName));
+    }
+
+    /**
+     * Determine if this id, is equals to the other id.
+     *
+     * @param ModelIdInterface $modelId The other id.
+     *
+     * @return bool
+     */
+    public function equals(ModelIdInterface $modelId)
+    {
+        // It is exactly the same id
+        if ($this === $modelId) {
+            return true;
+        }
+
+        return !(
+            // The data provider are not equal
+            $this->getDataProviderName() !== $modelId->getDataProviderName()
+            // The model ids are not equal
+            || $this->getId() !== $modelId->getId()
+        );
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
@@ -5,6 +5,7 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -12,31 +13,16 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
-use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
-use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
-
 /**
  * The class IdSerializer provides handy methods to serialize and un-serialize model ids including the data provider
  * name into a string.
  *
+ * @deprecated This class gonna be replaced by the ModelIdInterface. Use this instead!
+ *
  * @package DcGeneral\Contao\View\Contao2BackendView
  */
-class IdSerializer
+class IdSerializer extends ModelId
 {
-    /**
-     * The data provider name.
-     *
-     * @var string
-     */
-    protected $dataProviderName;
-
-    /**
-     * The id of the model.
-     *
-     * @var mixed
-     */
-    protected $modelId;
-
     /**
      * Set the data provider name.
      *
@@ -49,16 +35,6 @@ class IdSerializer
         $this->dataProviderName = $dataProviderName;
 
         return $this;
-    }
-
-    /**
-     * Retrieve the data provider name.
-     *
-     * @return string
-     */
-    public function getDataProviderName()
-    {
-        return $this->dataProviderName;
     }
 
     /**
@@ -76,96 +52,6 @@ class IdSerializer
     }
 
     /**
-     * Retrieve the id.
-     *
-     * @return mixed
-     */
-    public function getId()
-    {
-        return $this->modelId;
-    }
-
-    /**
-     * Create an instance from the passed values.
-     *
-     * @param string $dataProviderName The data provider name.
-     *
-     * @param mixed  $modelId          The id.
-     *
-     * @return IdSerializer
-     */
-    public static function fromValues($dataProviderName, $modelId)
-    {
-        $instance = new IdSerializer();
-
-        $instance
-            ->setId($modelId)
-            ->setDataProviderName($dataProviderName);
-
-        return $instance;
-    }
-
-    /**
-     * Create an instance from a model.
-     *
-     * @param ModelInterface $model The model.
-     *
-     * @return IdSerializer
-     */
-    public static function fromModel(ModelInterface $model)
-    {
-        return self::fromValues($model->getProviderName(), $model->getId());
-    }
-
-    /**
-     * Create an instance from an serialized id.
-     *
-     * @param string $serialized The id.
-     *
-     * @return IdSerializer
-     *
-     * @throws DcGeneralRuntimeException When invalid data is encountered.
-     */
-    public static function fromSerialized($serialized)
-    {
-        $instance = new IdSerializer();
-
-        $serialized = rawurldecode($serialized);
-        $serialized = html_entity_decode($serialized, ENT_QUOTES, 'UTF-8');
-
-        $chunks = explode('::', $serialized);
-
-        if (count($chunks) !== 2) {
-            throw new DcGeneralRuntimeException('Unparsable encoded id value: ' . var_export($serialized, true));
-        }
-
-        $instance->setDataProviderName($chunks[0]);
-
-        if (is_numeric($chunks[1])) {
-            return $instance->setId($chunks[1]);
-        }
-
-        $decodedSource = base64_decode($chunks[1]);
-        $decodedJson   = json_decode($decodedSource, true);
-
-        return $instance->setId($decodedJson ?: $decodedSource);
-    }
-
-    /**
-     * Serialize the id.
-     *
-     * @return string
-     */
-    public function getSerialized()
-    {
-        if (is_numeric($this->modelId)) {
-            return sprintf('%s::%s', $this->dataProviderName, $this->modelId);
-        }
-
-        return sprintf('%s::%s', $this->dataProviderName, base64_encode(json_encode($this->modelId)));
-    }
-
-    /**
      * Determine if both, data provider name and id are set and non empty.
      *
      * @return bool
@@ -173,27 +59,5 @@ class IdSerializer
     public function isValid()
     {
         return !(empty($this->modelId) || empty($this->dataProviderName));
-    }
-
-    /**
-     * Determine if this id, is equals to the other id.
-     *
-     * @param IdSerializer $idSerializer The other id.
-     *
-     * @return bool
-     */
-    public function equals(IdSerializer $idSerializer)
-    {
-        // It is exactly the same id
-        if ($this === $idSerializer) {
-            return true;
-        }
-
-        return !(
-            // The data provider are not equal
-            $this->getDataProviderName() !== $idSerializer->getDataProviderName()
-            // The model ids are not equal
-            || $this->getId() !== $idSerializer->getId()
-        );
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/ModelId.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/ModelId.php
@@ -9,7 +9,7 @@
  * @filesource
  */
 
-namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
+namespace ContaoCommunityAlliance\DcGeneral\Data;
 
 use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/ModelId.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/ModelId.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
+
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralInvalidArgumentException;
+use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
+
+/**
+ * The class ModelId implements the ModelIdInterface.
+ *
+ * It is the successor of the previous used ModelIdSerializer in the Contao2BackendView.
+ *
+ * @package DcGeneral\Contao\View\Contao2BackendView
+ */
+class ModelId implements ModelIdInterface
+{
+    /**
+     * The data provider name.
+     *
+     * @var string
+     */
+    protected $dataProviderName;
+
+    /**
+     * The id of the model.
+     *
+     * @var mixed
+     */
+    protected $modelId;
+
+    /**
+     * Construct.
+     *
+     * @param string $dataProviderName The data provider name.
+     * @param mixed  $modelId          The model id.
+     *
+     * @throws DcGeneralInvalidArgumentException If an invalid data provider name or model id is given.
+     */
+    public function __construct($dataProviderName, $modelId)
+    {
+        if (empty($dataProviderName)) {
+            throw new DcGeneralInvalidArgumentException('Can\'t instantiate model id. No data provider name given.');
+        }
+
+        if (empty($modelId)) {
+            throw new DcGeneralInvalidArgumentException('Can\'t instantiate model id. No model id given.');
+        }
+
+        $this->modelId          = $modelId;
+        $this->dataProviderName = $dataProviderName;
+    }
+
+    /**
+     * Retrieve the data provider name.
+     *
+     * @return string
+     */
+    public function getDataProviderName()
+    {
+        return $this->dataProviderName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->modelId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromValues($dataProviderName, $modelId)
+    {
+        return new static($dataProviderName, $modelId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromModel(ModelInterface $model)
+    {
+        return self::fromValues($model->getProviderName(), $model->getId());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function fromSerialized($serialized)
+    {
+        $serialized = rawurldecode($serialized);
+        $serialized = html_entity_decode($serialized, ENT_QUOTES, 'UTF-8');
+
+        $chunks = explode('::', $serialized);
+
+        if (count($chunks) !== 2) {
+            throw new DcGeneralRuntimeException('Unparsable encoded id value: ' . var_export($serialized, true));
+        }
+
+        if (!is_numeric($chunks[1])) {
+            $decodedSource = base64_decode($chunks[1]);
+            $decodedJson   = json_decode($decodedSource, true);
+
+            $chunks[1] = $decodedJson ?: $decodedSource;
+        }
+
+        return new static($chunks[0], $chunks[1]);
+    }
+
+    /**
+     * Serialize the id.
+     *
+     * @return string
+     */
+    public function getSerialized()
+    {
+        if (is_numeric($this->modelId)) {
+            return sprintf('%s::%s', $this->dataProviderName, $this->modelId);
+        }
+
+        return sprintf('%s::%s', $this->dataProviderName, base64_encode(json_encode($this->modelId)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function equals(ModelIdInterface $modelId)
+    {
+        // It is exactly the same id
+        if ($this === $modelId) {
+            return true;
+        }
+
+        return !(
+            // The data provider are not equal
+            $this->getDataProviderName() !== $modelId->getDataProviderName()
+            // The model ids are not equal
+            || $this->getId() !== $modelId->getId()
+        );
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/ModelIdInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/ModelIdInterface.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * The MetaModels extension allows the creation of multiple collections of custom items,
+ * each with its own unique set of selectable attributes, with attribute extendability.
+ * The Front-End modules allow you to build powerful listing and filtering of the
+ * data in each collection.
+ *
+ * PHP version 5
+ *
+ * @package    MetaModels
+ * @subpackage Core
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Data;
+
+use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
+
+/**
+ * Interface ModelIdInterface.
+ *
+ * This interface the model id which identifies an model.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Data
+ */
+interface ModelIdInterface
+{
+    /**
+     * Retrieve the data provider name.
+     *
+     * @return string
+     */
+    public function getDataProviderName();
+
+    /**
+     * Retrieve the id.
+     *
+     * @return mixed
+     */
+    public function getId();
+
+    /**
+     * Create an instance from the passed values.
+     *
+     * @param string $dataProviderName The data provider name.
+     *
+     * @param mixed  $modelId          The id.
+     *
+     * @return ModelIdInterface
+     */
+    public static function fromValues($dataProviderName, $modelId);
+
+    /**
+     * Create an instance from a model.
+     *
+     * @param ModelInterface $model The model.
+     *
+     * @return ModelIdInterface
+     */
+    public static function fromModel(ModelInterface $model);
+
+    /**
+     * Create an instance from an serialized id.
+     *
+     * @param string $serialized The id.
+     *
+     * @return ModelIdInterface
+     *
+     * @throws DcGeneralRuntimeException When invalid data is encountered.
+     */
+    public static function fromSerialized($serialized);
+
+    /**
+     * Serialize the id.
+     *
+     * @return string
+     */
+    public function getSerialized();
+
+    /**
+     * Determine if this id, is equals to the other id.
+     *
+     * @param ModelIdInterface $modelId The other model id.
+     *
+     * @return bool
+     */
+    public function equals(ModelIdInterface $modelId);
+}


### PR DESCRIPTION
As proposed in #85 this pull request provides an implemenation of a generic model id and would replace the IdSerializer in the future.

This implementation introduces the an interface and implemtation of it. This would make the transition between IdSerializer and ModelId easier.

The model id is implemented as an immutable object so that we can benefit from the characteristic advantages of an immutable object:
 * Be sure that the object referes to the same model.
 * Be sure a valid id exists (No empty provider name or id).

At the moment the IdSerializer is not replaced anywhere. This could be done afterwards if this pull request is accepted.