### PR TITLE
Copy without manual sorting

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
@@ -127,6 +127,11 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
         $name   = $action->getName();
 
         switch ($name) {
+            case 'copy':
+                if (!method_exists($this, $name)) {
+                    break;
+                }
+                // no break
             case 'create':
             case 'paste':
             case 'delete':

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
@@ -170,6 +170,11 @@ class ClipboardController implements EventSubscriberInterface
                     }
                 }
 
+                // Only push item to clipboard if manual sorting is used.
+                if (Item::COPY === $clipboardActionName && !ViewHelpers::getManualSortingProperty($environment)) {
+                    return;
+                }
+
                 // create the new item
                 $item = new Item($clipboardActionName, $parentId, $modelId);
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
@@ -318,8 +318,6 @@ class ListView extends BaseView
      */
     public function copy(Action $action)
     {
-        // FIXME this will never be used anymore!
-
         if ($this->environment->getDataDefinition()->getBasicDefinition()->isEditOnlyMode()) {
             return $this->edit($action);
         }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
@@ -645,8 +645,6 @@ class ParentView extends BaseView
      */
     public function copy(Action $action)
     {
-        // FIXME this will never be used anymore!
-
         if ($this->environment->getDataDefinition()->getBasicDefinition()->isEditOnlyMode()) {
             return $this->edit($action);
         }


### PR DESCRIPTION
This pull requests fixes the copy of an item when no sorting property is used (See metamodels/core#743).

* It moves the base config sorting initialization to the `BackendViewPopulator` as the base config sorting is a base requirement for many cases. Here it's required to detect non manual sorting property in the ClipboardController. Afaik there's no case where it would cause an unexpected behaviour. Do you know any edge cases,  @discordier?
* It prevents the clipboard to handle such copy actions.
* It uses the still existing View::copy methods instead if no manual sorting property is used.

There is still an issue: 
 * If there is a manual sorting property which is not used in the current view, it would be duplicated. So the same sorting value would exists. Can this break the manual sorting or is this "fixed" by the next sorting operation? I could not detect an unexpected behaviour but did not know all edge cases.