### PR TITLE
Support sorting in the fileTree

### DIFF
--- a/contao/config/autoload.php
+++ b/contao/config/autoload.php
@@ -33,6 +33,7 @@ TemplateLoader::addFiles(
         'dcbe_general_breadcrumb'       => 'system/modules/dc-general/templates',
         'dcbe_general_clipboard'        => 'system/modules/dc-general/templates',
         'dcbe_general_grouping'         => 'system/modules/dc-general/templates',
+        'widget_filetree'               => 'system/modules/dc-general/templates',
         'widget_treepicker'             => 'system/modules/dc-general/templates',
         'widget_treepicker_popup'       => 'system/modules/dc-general/templates',
         'widget_treepicker_entry'       => 'system/modules/dc-general/templates',

--- a/contao/config/autoload.php
+++ b/contao/config/autoload.php
@@ -34,6 +34,7 @@ TemplateLoader::addFiles(
         'dcbe_general_clipboard'        => 'system/modules/dc-general/templates',
         'dcbe_general_grouping'         => 'system/modules/dc-general/templates',
         'widget_filetree'               => 'system/modules/dc-general/templates',
+        'widget_filetree_order'         => 'system/modules/dc-general/templates',
         'widget_treepicker'             => 'system/modules/dc-general/templates',
         'widget_treepicker_popup'       => 'system/modules/dc-general/templates',
         'widget_treepicker_entry'       => 'system/modules/dc-general/templates',

--- a/contao/templates/widget_filetree.html5
+++ b/contao/templates/widget_filetree.html5
@@ -1,0 +1,16 @@
+<input type="hidden" name="<?php echo $this->name; ?>" id="ctrl_<?php echo $this->id; ?>" value="<?php echo $this->value; ?>">
+<div class="selector_container">
+    <?php if ($this->hasOrder && count($this->icons) > 1): ?>
+        <p class="sort_hint"><?php echo $this->translate('dragItemsHint'); ?></p>
+    <?php endif; ?>
+    <ul id="sort_<?php echo $this->id; ?>" class="<?php echo trim(($this->hasOrder ? 'sortable ' : '') . ($this->isGallery ? 'sgallery' : '')); ?>">
+    <?php foreach ($this->icons as $id => $icon): ?>
+        <li data-id="<?php echo \String::binToUuid($id); ?>"><?php echo $icon; ?></li>
+    <?php endforeach; ?>
+    </ul>
+</div>
+<p>
+    <a href="<?php echo $this->link; ?>" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalSelector({'width':768,'title':'<?php echo $this->translate('filepicker'); ?>','url':this.href,'id':'<?php echo $this->id; ?>'});return false"><?php echo $this->translate('changeSelection'); ?></a>
+</p>
+<?php if ($this->hasOrder): ?>
+<?php endif; ?>

--- a/contao/templates/widget_filetree.html5
+++ b/contao/templates/widget_filetree.html5
@@ -1,7 +1,7 @@
 <input type="hidden" name="<?php echo $this->name; ?>" id="ctrl_<?php echo $this->id; ?>" value="<?php echo $this->value; ?>">
 <div class="selector_container">
     <?php if ($this->hasOrder && count($this->icons) > 1): ?>
-        <p class="sort_hint"><?php echo $this->translate('dragItemsHint'); ?></p>
+        <p class="sort_hint"><?php echo $this->translate('dragItemsHint', 'MSC'); ?></p>
     <?php endif; ?>
     <ul id="sort_<?php echo $this->id; ?>" class="<?php echo trim(($this->hasOrder ? 'sortable ' : '') . ($this->isGallery ? 'sgallery' : '')); ?>">
     <?php foreach ($this->icons as $id => $icon): ?>
@@ -10,7 +10,7 @@
     </ul>
 </div>
 <p>
-    <a href="<?php echo $this->link; ?>" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalSelector({'width':768,'title':'<?php echo $this->translate('filepicker'); ?>','url':this.href,'id':'<?php echo $this->id; ?>'});return false"><?php echo $this->translate('changeSelection'); ?></a>
+    <a href="<?php echo $this->link; ?>" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalSelector({'width':768,'title':'<?php echo $this->translate('filepicker', 'MSC'); ?>','url':this.href,'id':'<?php echo $this->id; ?>'});return false"><?php echo $this->translate('changeSelection', 'MSC'); ?></a>
 </p>
 <?php if ($this->hasOrder): ?>
     <script>Backend.makeMultiSrcSortable("sort_<?php echo $this->id; ?>", "ctrl_<?php echo $this->orderId; ?>")</script>

--- a/contao/templates/widget_filetree.html5
+++ b/contao/templates/widget_filetree.html5
@@ -13,4 +13,5 @@
     <a href="<?php echo $this->link; ?>" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalSelector({'width':768,'title':'<?php echo $this->translate('filepicker'); ?>','url':this.href,'id':'<?php echo $this->id; ?>'});return false"><?php echo $this->translate('changeSelection'); ?></a>
 </p>
 <?php if ($this->hasOrder): ?>
+    <script>Backend.makeMultiSrcSortable("sort_<?php echo $this->id; ?>", "ctrl_<?php echo $this->orderId; ?>")</script>
 <?php endif; ?>

--- a/contao/templates/widget_filetree_order.html5
+++ b/contao/templates/widget_filetree_order.html5
@@ -1,0 +1,1 @@
+<input type="hidden" name="<?php echo $this->strName; ?>" value="<?php echo $this->getSerializedValue(); ?>" id="<?php echo $this->strId; ?>" />

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
@@ -13,14 +13,57 @@
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
 use ContaoCommunityAlliance\DcGeneral\View\ViewTemplateInterface;
+use ContaoCommunityAlliance\Translator\TranslatorInterface;
 
 /**
  * This class is used for the contao backend view as template.
  *
  * @package DcGeneral\View
  */
-class ContaoBackendViewTemplate extends \BackendTemplate implements ViewTemplateInterface
+class ContaoBackendViewTemplate extends \BackendTemplate implements ViewTemplateInterface, TranslatorInterface
 {
+    /**
+     * The translator.
+     *
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * Construct.
+     *
+     * @param string              $strTemplate    The template name.
+     * @param string              $strContentType the content type.
+     */
+    public function __construct($strTemplate = '', $strContentType = 'text/html')
+    {
+        parent::__construct($strTemplate, $strContentType);
+    }
+
+    /**
+     * Get the translator.
+     *
+     * @return TranslatorInterface
+     */
+    public function getTranslator()
+    {
+        return $this->translator;
+    }
+
+    /**
+     * Set the translator.
+     *
+     * @param TranslatorInterface $translator The translator.
+     *
+     * @return $this
+     */
+    public function setTranslator(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+
+        return $this;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -47,5 +90,29 @@ class ContaoBackendViewTemplate extends \BackendTemplate implements ViewTemplate
     public function get($name)
     {
         return $this->$name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function translate($string, $domain = null, array $parameters = array(), $locale = null)
+    {
+        if ($this->translator) {
+            return $this->translator->translate($string, $domain, $parameters, $locale);
+        }
+
+        return $string;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function translatePluralized($string, $number, $domain = null, array $parameters = array(), $locale = null)
+    {
+        if ($this->translator) {
+            return $this->translator->translate($string, $number, $domain, $parameters, $locale);
+        }
+
+        return $string;
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
@@ -110,7 +110,7 @@ class ContaoBackendViewTemplate extends \BackendTemplate implements ViewTemplate
     public function translatePluralized($string, $number, $domain = null, array $parameters = array(), $locale = null)
     {
         if ($this->translator) {
-            return $this->translator->translate($string, $number, $domain, $parameters, $locale);
+            return $this->translator->translatePluralized($string, $number, $domain, $parameters, $locale);
         }
 
         return $string;

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -6,6 +6,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     Christopher Boelter <christopher@boelter.eu>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -53,6 +54,16 @@ class ContaoWidgetManager
      * @var ModelInterface
      */
     protected $model;
+
+    /**
+     * Mapping list of widget types where the DC General has it own widgets.
+     *
+     * @var array
+     */
+    protected $widgetMapping = array(
+        'fileTree'      => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTree',
+        'fileTreeOrder' => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTreeOrder'
+    );
 
     /**
      * Create a new instance.
@@ -428,6 +439,10 @@ class ContaoWidgetManager
      */
     protected function getWidgetClass(PropertyInterface $property)
     {
+        if (isset($this->widgetMapping[$property->getWidgetType()])) {
+            return $this->widgetMapping[$property->getWidgetType()];
+        }
+
         if (!isset($GLOBALS['BE_FFL'][$property->getWidgetType()])) {
             return null;
         }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/AbstractWidget.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/AbstractWidget.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget;
+
+use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
+use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
+
+/**
+ * Abstract widget class as base for dc general backend widgets.
+ *
+ * This widget is only prepared to run in DcCompat mode!
+ */
+abstract class AbstractWidget extends \Widget
+{
+    /**
+     * Submit user input.
+     *
+     * @var boolean
+     */
+    protected $blnSubmitInput = true;
+
+    /**
+     * The template.
+     *
+     * @var string
+     */
+    protected $strTemplate = 'be_widget';
+
+    /**
+     * The data Container.
+     *
+     * @var DcCompat
+     */
+    protected $dataContainer;
+
+    /**
+     * Create a new instance.
+     *
+     * @param array      $attributes    The custom attributes.
+     *
+     * @param DcCompat   $dataContainer The data container.
+     */
+    public function __construct($attributes = null, DcCompat $dataContainer = null)
+    {
+        parent::__construct($attributes);
+
+        $this->dataContainer = $dataContainer ?: $this->objDca;
+    }
+
+    /**
+     * Get the environment.
+     *
+     * @return EnvironmentInterface
+     */
+    public function getEnvironment()
+    {
+        return $this->dataContainer->getEnvironment();
+    }
+
+    /**
+     * Get the model.
+     *
+     * @return ModelInterface
+     */
+    public function getModel()
+    {
+        return $this->dataContainer->getModel();
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/AbstractWidget.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/AbstractWidget.php
@@ -47,9 +47,9 @@ abstract class AbstractWidget extends \Widget
     /**
      * Create a new instance.
      *
-     * @param array|null      $attributes    The custom attributes.
+     * @param array|null    $attributes    The custom attributes.
      *
-     * @param DcCompat|null   $dataContainer The data container.
+     * @param DcCompat|null $dataContainer The data container.
      */
     public function __construct($attributes = null, DcCompat $dataContainer = null)
     {

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/AbstractWidget.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/AbstractWidget.php
@@ -47,9 +47,9 @@ abstract class AbstractWidget extends \Widget
     /**
      * Create a new instance.
      *
-     * @param array      $attributes    The custom attributes.
+     * @param array|null      $attributes    The custom attributes.
      *
-     * @param DcCompat   $dataContainer The data container.
+     * @param DcCompat|null   $dataContainer The data container.
      */
     public function __construct($attributes = null, DcCompat $dataContainer = null)
     {

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
@@ -12,6 +12,7 @@
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget;
 
 use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ContaoBackendViewTemplate;
 use Model\Collection;
 
 /**
@@ -319,28 +320,23 @@ class FileTree extends AbstractWidget
             $icons = $this->applySorting($icons);
         }
 
-        $translator = $this->getEnvironment()->getTranslator();
-        $template   = new \BackendTemplate($this->subTemplate);
-
-        $template->translate = function ($string, $domain = 'MSC', $parameters = array()) use ($translator) {
-            return $translator->translate($string, $domain, $parameters);
-        };
-
-        $template->name      = $this->strName;
-        $template->id        = $this->strId;
-        $template->value     = implode(',', array_map('String::binToUuid', $values));
-        $template->hasOrder  = ($this->orderField != '' && is_array($this->orderFieldValue));
-        $template->icons     = $icons;
-        $template->isGallery = $this->isGallery;
-        $template->orderId   = $this->orderId;
-        $template->link      = $this->generateLink($values);
-
-        $return = $template->parse();
+        $template = new ContaoBackendViewTemplate($this->subTemplate);
+        $buffer   = $template
+            ->setTranslator($this->getEnvironment()->getTranslator())
+            ->set('name', $this->strName)
+            ->set('id', $this->strId)
+            ->set('value', implode(',', array_map('String::binToUuid', $values)))
+            ->set('hasOrder', ($this->orderField != '' && is_array($this->orderFieldValue)))
+            ->set('icons', $icons)
+            ->set('isGallery', $this->isGallery)
+            ->set('orderId', $this->orderId)
+            ->set('link', $this->generateLink($values))
+            ->parse();
 
         if (!\Environment::get('isAjaxRequest')) {
-            $return = '<div>' . $return . '</div>';
+            $buffer = '<div>' . $buffer . '</div>';
         }
 
-        return $return;
+        return $buffer;
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
@@ -66,19 +66,17 @@ class FileTree extends AbstractWidget
     {
         parent::__construct($attributes, $dataContainer);
 
-        $this->setUp($dataContainer);
+        $this->setUp();
     }
 
     /**
      * Setup the file tree widget.
      *
-     * @param DcCompat|null $dataContainer The data container.
-     *
      * @return void
      *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
-    private function setUp(DcCompat $dataContainer = null)
+    private function setUp()
     {
         // Load the fonts for the drag hint (see #4838)
         $GLOBALS['TL_CONFIG']['loadGoogleFonts'] = true;
@@ -87,7 +85,7 @@ class FileTree extends AbstractWidget
             return;
         }
 
-        $value = $dataContainer->getModel()->getProperty($this->orderField);
+        $value = $this->dataContainer->getModel()->getProperty($this->orderField);
 
         // support serialized values.
         if (!is_array($value)) {

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
@@ -17,6 +17,12 @@ use Model\Collection;
 /**
  * File tree widget being compatible with the dc general.
  *
+ * @property string strField    The field name.
+ * @property bool   mandatory   If true the field is required.
+ * @property bool   multiple    If true multiple values are allowed.
+ * @property bool   isGallery   If true the a image gallery is rendered.
+ * @property bool   isDownloads If true only allowed download files are listed.
+ *
  * @see https://github.com/contao/core/blob/master/system/modules/core/widgets/FileTree.php
  */
 class FileTree extends AbstractWidget
@@ -52,9 +58,9 @@ class FileTree extends AbstractWidget
     /**
      * Create a new instance.
      *
-     * @param array    $attributes    The custom attributes.
+     * @param array|null    $attributes    The custom attributes.
      *
-     * @param DcCompat $dataContainer The data container.
+     * @param DcCompat|null $dataContainer The data container.
      */
     public function __construct($attributes = null, DcCompat $dataContainer = null)
     {
@@ -66,13 +72,13 @@ class FileTree extends AbstractWidget
     /**
      * Setup the file tree widget.
      *
-     * @param DcCompat $dataContainer The data container.
+     * @param DcCompat|null $dataContainer The data container.
      *
      * @return void
      *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
-    private function setUp(DcCompat $dataContainer)
+    private function setUp(DcCompat $dataContainer = null)
     {
         // Load the fonts for the drag hint (see #4838)
         $GLOBALS['TL_CONFIG']['loadGoogleFonts'] = true;
@@ -122,10 +128,10 @@ class FileTree extends AbstractWidget
     /**
      * Render the file list.
      *
-     * @param array       $values        The selected values.
-     * @param array       $icons         The generated icons.
-     * @param Collection  $collection    The files collection.
-     * @param bool        $followSubDirs If true subfolders get rendered.
+     * @param array           $values        The selected values.
+     * @param array           $icons         The generated icons.
+     * @param Collection|null $collection    The files collection.
+     * @param bool            $followSubDirs If true subfolders get rendered.
      *
      * @return void
      */
@@ -146,12 +152,12 @@ class FileTree extends AbstractWidget
             if ($this->isGallery && !$this->isDownloads) {
                 $icons[$model->uuid] = $this->renderIcon($model);
             } elseif ($model->type === 'folder' && $followSubDirs) {
-                $subCollection  = \FilesModel::findByPid($model->uuid);
+                $subCollection = \FilesModel::findByPid($model->uuid);
                 $this->renderList($values, $icons, $subCollection);
             } else {
                 $icon = $this->renderIcon($model, $this->isGallery, $this->isDownloads);
 
-                if ($icon) {
+                if ($icon !== false) {
                     $icons[$model->uuid] = $icon;
                 }
             }
@@ -199,7 +205,7 @@ class FileTree extends AbstractWidget
      * @param bool        $imagesOnly If true only images are rendered.
      * @param bool        $downloads  If true file extension has to be in the allowed downloads list.
      *
-     * @return bool|string
+     * @return false|string
      */
     protected function renderIcon($model, $imagesOnly = false, $downloads = false)
     {
@@ -213,7 +219,7 @@ class FileTree extends AbstractWidget
             return \Image::getHtml('folderC.gif') . ' ' . $model->path;
         }
 
-        $info = $this->renderFileInfo($model);
+        $info = $this->renderFileInfo($file);
 
         if ($imagesOnly && !($file->isGdImage || $file->isSvgImage)) {
             return false;
@@ -306,8 +312,8 @@ class FileTree extends AbstractWidget
      */
     public function generate()
     {
-        $values   = array();
-        $icons    = array();
+        $values = array();
+        $icons  = array();
 
         if (!empty($this->varValue)) {
             $files = \FilesModel::findMultipleByUuids((array)$this->varValue);
@@ -315,8 +321,8 @@ class FileTree extends AbstractWidget
             $icons = $this->applySorting($icons);
         }
 
-        $translator    = $this->getEnvironment()->getTranslator();
-        $template      = new \BackendTemplate($this->subTemplate);
+        $translator = $this->getEnvironment()->getTranslator();
+        $template   = new \BackendTemplate($this->subTemplate);
 
         $template->translate = function ($string, $domain = 'MSC', $parameters = array()) use ($translator) {
             return $translator->translate($string, $domain, $parameters);

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget;
+
+use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
+use Model\Collection;
+
+/**
+ * File tree widget being compatible with the dc general.
+ *
+ * @see https://github.com/contao/core/blob/master/system/modules/core/widgets/FileTree.php
+ */
+class FileTree extends AbstractWidget
+{
+    /**
+     * The widget sub template.
+     *
+     * @var string
+     */
+    private $subTemplate = 'widget_filetree';
+
+    /**
+     *  Css ID of the order field.
+     *
+     * @var string
+     */
+    protected $orderId;
+
+    /**
+     * The order field attribute name.
+     *
+     * @var string.
+     */
+    protected $orderField;
+
+    /**
+     * The order field value.
+     *
+     * @var array.
+     */
+    protected $orderFieldValue;
+
+    /**
+     * Create a new instance.
+     *
+     * @param array    $attributes    The custom attributes.
+     *
+     * @param DcCompat $dataContainer The data container.
+     */
+    public function __construct($attributes = null, DcCompat $dataContainer = null)
+    {
+        parent::__construct($attributes, $dataContainer);
+
+        $this->setUp($dataContainer);
+    }
+
+    /**
+     * Setup the file tree widget.
+     *
+     * @param DcCompat $dataContainer The data container.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    private function setUp(DcCompat $dataContainer)
+    {
+        // Load the fonts for the drag hint (see #4838)
+        $GLOBALS['TL_CONFIG']['loadGoogleFonts'] = true;
+
+        if (!$this->dataContainer || !$this->orderField) {
+            return;
+        }
+
+        $value = $dataContainer->getModel()->getProperty($this->orderField);
+
+        // support serialized values.
+        if (!is_array($value)) {
+            $value = deserialize($value, true);
+        }
+
+        $this->orderId         = $this->orderField . str_replace($this->strField, '', $this->strId);
+        $this->orderFieldValue = (!empty($value) && is_array($value)) ? array_filter($value) : array();
+    }
+
+    /**
+     * Process the validation.
+     *
+     * @param mixed $inputValue The input value.
+     *
+     * @return array|string
+     */
+    protected function validator($inputValue)
+    {
+        $translator = $this->getEnvironment()->getTranslator();
+
+        if ($inputValue == '') {
+            if ($this->mandatory) {
+                $this->addError($translator->translate('mandatory', 'ERR', array($this->strLabel)));
+            }
+
+            return '';
+        }
+
+        $inputValue = array_map(
+            'String::uuidToBin',
+            array_filter(explode(',', $inputValue))
+        );
+
+        return $this->multiple ? $inputValue : $inputValue[0];
+    }
+
+    /**
+     * Render the file list.
+     *
+     * @param array       $values        The selected values.
+     * @param array       $icons         The generated icons.
+     * @param Collection  $collection    The files collection.
+     * @param bool        $followSubDirs If true subfolders get rendered.
+     *
+     * @return void
+     */
+    private function renderList(array &$values, array &$icons, Collection $collection = null, $followSubDirs = false)
+    {
+        if (!$collection) {
+            return;
+        }
+
+        foreach ($collection as $model) {
+            // File system and database seem not in sync
+            if (!file_exists(TL_ROOT . '/' . $model->path)) {
+                continue;
+            }
+
+            $values[$model->id] = $model->uuid;
+
+            if ($this->isGallery && !$this->isDownloads) {
+                $icons[$model->uuid] = $this->renderIcon($model);
+            } elseif ($model->type === 'folder' && $followSubDirs) {
+                $subCollection  = \FilesModel::findByPid($model->uuid);
+                $this->renderList($values, $icons, $subCollection);
+            } else {
+                $icon = $this->renderIcon($model, $this->isGallery, $this->isDownloads);
+
+                if ($icon) {
+                    $icons[$model->uuid] = $icon;
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if an extension is in the allowed downloads.
+     *
+     * @param string $extension The file extension.
+     *
+     * @return bool
+     */
+    protected function isAllowedDownload($extension)
+    {
+        static $allowedDownload;
+
+        if ($allowedDownload === null) {
+            $allowedDownload = trimsplit(',', strtolower(\Config::get('allowedDownload')));
+        }
+
+        return in_array($extension, $allowedDownload);
+    }
+
+    /**
+     * Render the file info.
+     *
+     * @param \File $file The file.
+     *
+     * @return string
+     */
+    protected function renderFileInfo($file)
+    {
+        return sprintf(
+            '%s <span class="tl_gray">(%s&s)</span>',
+            $this->getReadableSize($file->size),
+            (($file->isGdImage || $file->isSvgImage) ? ', ' . $file->width . 'x' . $file->height . ' px' : '')
+        );
+    }
+
+    /**
+     * Render the image of a file.
+     *
+     * @param \FilesModel $model      The file model.
+     * @param bool        $imagesOnly If true only images are rendered.
+     * @param bool        $downloads  If true file extension has to be in the allowed downloads list.
+     *
+     * @return bool|string
+     */
+    protected function renderIcon($model, $imagesOnly = false, $downloads = false)
+    {
+        $file = new \File($model->path, true);
+
+        if ($model->type === 'folder') {
+            if ($imagesOnly || $downloads) {
+                return false;
+            }
+
+            return \Image::getHtml('folderC.gif') . ' ' . $model->path;
+        }
+
+        $info = $this->renderFileInfo($model);
+
+        if ($imagesOnly && !($file->isGdImage || $file->isSvgImage)) {
+            return false;
+        }
+
+        if ($downloads) {
+            if ($this->isAllowedDownload($file->extension)) {
+                return \Image::getHtml($file->icon) . ' ' . $info;
+            }
+
+            return false;
+        }
+
+        if (!$file->isGdImage && !$file->isSvgImage) {
+            return \Image::getHtml($file->icon) . ' ' . $info;
+        }
+
+        $image = 'placeholder.png';
+
+        if ($file->isSvgImage
+            || $file->height <= \Config::get('gdMaxImgHeight') && $file->width <= \Config::get('gdMaxImgWidth')
+        ) {
+            $image = \Image::get($model->path, 80, 60, 'center_center');
+        }
+
+        return \Image::getHtml($image, '', 'class="gimage" title="' . specialchars($info) . '"');
+    }
+
+    /**
+     * Apply the sorting to the icons.
+     *
+     * @param array $icons The file icons.
+     *
+     * @return array
+     */
+    private function applySorting($icons)
+    {
+        if ($this->orderField != '' && is_array($this->orderFieldValue)) {
+            $ordered = array();
+
+            foreach ($this->orderFieldValue as $uuid) {
+                if (isset($icons[$uuid])) {
+                    $ordered[$uuid] = $icons[$uuid];
+                    unset($icons[$uuid]);
+                }
+            }
+
+            foreach ($icons as $uuid => $icon) {
+                $ordered[$uuid] = $icon;
+            }
+
+            $icons = $ordered;
+        }
+
+        return $icons;
+    }
+
+    /**
+     * Generate the adjust selection link.
+     *
+     * @param array $values The selected files.
+     *
+     * @return string
+     */
+    private function generateLink($values)
+    {
+        $inputProvider = $this->getEnvironment()->getInputProvider();
+
+        // Contao passed File ids sinc 3.3.4
+        // @see https://github.com/contao/core/commit/c1472209fdfd6e2446013430753ed65530b5a1d1
+        if (version_compare(VERSION, '3.3.4', '>=')) {
+            $values = array_keys($values);
+        } else {
+            $values = array_map('String::binToUuid', $values);
+        }
+
+        return sprintf(
+            'contao/file.php?do=%s&amp;table=%s&amp;field=%s&amp;act=show&amp;id=%s&amp;value=%s&amp;rt=%s',
+            $inputProvider->getParameter('do'),
+            $this->getModel()->getProviderName(),
+            $this->strField,
+            $this->getModel()->getId(),
+            implode(',', $values),
+            \RequestToken::get()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate()
+    {
+        $values   = array();
+        $icons    = array();
+
+        if (!empty($this->varValue)) {
+            $files = \FilesModel::findMultipleByUuids((array)$this->varValue);
+            $this->renderList($values, $icons, $files, true);
+            $icons = $this->applySorting($icons);
+        }
+
+        $translator    = $this->getEnvironment()->getTranslator();
+        $template      = new \BackendTemplate($this->subTemplate);
+
+        $template->translate = function ($string, $domain = 'MSC', $parameters = array()) use ($translator) {
+            return $translator->translate($string, $domain, $parameters);
+        };
+
+        $template->name      = $this->strName;
+        $template->id        = $this->strId;
+        $template->value     = implode(',', array_map('String::binToUuid', $values));
+        $template->hasOrder  = ($this->orderField != '' && is_array($this->orderFieldValue));
+        $template->icons     = $icons;
+        $template->isGallery = $this->isGallery;
+        $template->orderId   = $this->orderId;
+        $template->link      = $this->generateLink($values);
+
+        $return = $template->parse();
+
+        if (!\Environment::get('isAjaxRequest')) {
+            $return = '<div>' . $return . '</div>';
+        }
+
+        return $return;
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTreeOrder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTreeOrder.php
@@ -23,7 +23,7 @@ class FileTreeOrder extends AbstractWidget
      *
      * @var string
      */
-    protected $strTemplate = 'be_widget_rdo';
+    protected $strTemplate = 'widget_filetree_order';
 
     /**
      * {@inheritdoc}
@@ -42,11 +42,18 @@ class FileTreeOrder extends AbstractWidget
      */
     public function generate()
     {
-        return sprintf(
-            '<input type="hidden" name="%s" value="%s" id="ctrl_%s" />',
-            $this->strName,
-            implode(',', array_map('String::binToUuid', $this->varValue)),
-            $this->strId
-        );
+        // Nothing to do here. Markup is in the widget template.
+
+        return '';
+    }
+
+    /**
+     * Get the value serialized as string.
+     *
+     * @return string
+     */
+    protected function getSerializedValue()
+    {
+        return implode(',', array_map('String::binToUuid', $this->varValue));
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTreeOrder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTreeOrder.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget;
+
+/**
+ * This widget is a supporting widget to store the file tree orderings.
+ *
+ * The ContaoWidgetManager does not allow input values without a widget. This is used as helper widget instead.
+ */
+class FileTreeOrder extends AbstractWidget
+{
+    /**
+     * The template.
+     *
+     * @var string
+     */
+    protected $strTemplate = 'be_widget_rdo';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function validator($inputValue)
+    {
+        $inputValue = array_map('String::uuidToBin', array_filter(explode(',', $inputValue)));
+
+        return $inputValue;
+    }
+
+    /**
+     * Generate the widget and return it as string.
+     *
+     * @return string The widget markup
+     */
+    public function generate()
+    {
+        return sprintf(
+            '<input type="hidden" name="%s" value="%s" id="ctrl_%s" />',
+            $this->strName,
+            implode(',', array_map('String::binToUuid', $this->varValue)),
+            $this->strId
+        );
+    }
+}


### PR DESCRIPTION
This pull requests enables the DcGeneral to handle the sorting of the fileTree as the first step to support https://github.com/MetaModels/attribute_file/issues/8.

It splits the fileTree into two widgets. The fileTree itself and the fileTreeOrderField. By this approach we don't have to hack the ContaoWidgetManager completely to handle non widget field input. Besides there's no separate magic writing into the database/model required.

**Todo:** To support legacy datacontainer definitions where should be a compatibility layer in the data definition builder to set the inputType of the orderField property.