### PR TITLE
Feature/widget manager cleanup

### DIFF
--- a/contao/config/event_listeners.php
+++ b/contao/config/event_listeners.php
@@ -19,6 +19,7 @@ use ContaoCommunityAlliance\DcGeneral\Contao\Dca\Populator\ExtendedLegacyDcaPopu
 use ContaoCommunityAlliance\DcGeneral\Contao\Dca\Populator\HardCodedPopulator;
 use ContaoCommunityAlliance\DcGeneral\Contao\Dca\Populator\PickerCompatPopulator;
 use ContaoCommunityAlliance\DcGeneral\Contao\Subscriber\FormatModelLabelSubscriber;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\BuildWidgetEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetGroupHeaderEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Subscriber\GetGroupHeaderSubscriber;
 use ContaoCommunityAlliance\DcGeneral\DcGeneralEvents;
@@ -65,4 +66,7 @@ return array(
     GetGroupHeaderEvent::NAME => array(
         array(new GetGroupHeaderSubscriber(), 'handle')
     ),
+    BuildWidgetEvent::NAME => array(
+        'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Subscriber\WidgetBuilder::handleEvent'
+    )
 );

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -14,16 +14,9 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
-use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
-use ContaoCommunityAlliance\Contao\Bindings\Events\Backend\AddToUrlEvent;
-use ContaoCommunityAlliance\Contao\Bindings\Events\Image\GenerateHtmlEvent;
-use ContaoCommunityAlliance\Contao\Bindings\Events\Widget\GetAttributesFromDcaEvent;
-use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\BuildWidgetEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\DecodePropertyValueForWidgetEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\EncodePropertyValueFromWidgetEvent;
-use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetPropertyOptionsEvent;
-use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\ManipulateWidgetEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\ResolveWidgetErrorMessageEvent;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\PropertyValueBag;
@@ -54,16 +47,6 @@ class ContaoWidgetManager
      * @var ModelInterface
      */
     protected $model;
-
-    /**
-     * Mapping list of widget types where the DC General has it own widgets.
-     *
-     * @var array
-     */
-    protected $widgetMapping = array(
-        'fileTree'      => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTree',
-        'fileTreeOrder' => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTreeOrder'
-    );
 
     /**
      * Create a new instance.
@@ -166,178 +149,6 @@ class ContaoWidgetManager
     }
 
     /**
-     * Get the help wizard.
-     *
-     * @param PropertyInterface $propInfo The property for which the wizard shall be generated.
-     *
-     * @return string
-     */
-    protected function getHelpWizard($propInfo)
-    {
-        $helpWizard  = '';
-        $environment = $this->getEnvironment();
-        $dispatcher  = $environment->getEventDispatcher();
-        $defName     = $environment->getDataDefinition()->getName();
-        $translator  = $environment->getTranslator();
-        // Add the help wizard.
-        if ($propInfo->getExtra() && array_key_exists('helpwizard', $propInfo->getExtra())) {
-            $event = new GenerateHtmlEvent(
-                'about.gif',
-                $translator->translate('helpWizard', 'MSC'),
-                'style="vertical-align:text-bottom;"'
-            );
-
-            $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $event);
-
-            $helpWizard .= sprintf(
-                ' <a href="contao/help.php?table=%s&amp;field=%s" ' .
-                'title="%s" ' .
-                'onclick="Backend.openWindow(this, 600, 500); return false;">%s</a>',
-                $defName,
-                $propInfo->getName(),
-                specialchars($translator->translate('helpWizard', 'MSC')),
-                $event->getHtml()
-            );
-        }
-
-        return $helpWizard;
-    }
-
-    /**
-     * Get the table import wizard.
-     *
-     * @return string
-     */
-    protected function getTableWizard()
-    {
-        $environment = $this->getEnvironment();
-        $dispatcher  = $environment->getEventDispatcher();
-        $defName     = $environment->getDataDefinition()->getName();
-        $translator  = $environment->getTranslator();
-        $urlEvent    = new AddToUrlEvent('key=table');
-
-        $importTableEvent = new GenerateHtmlEvent(
-            'tablewizard.gif',
-            $translator->translate('importTable.0', $defName),
-            'style="vertical-align:text-bottom;"'
-        );
-
-        $shrinkEvent = new GenerateHtmlEvent(
-            'demagnify.gif',
-            $translator->translate('shrink.0', $defName),
-            sprintf(
-                'title="%s" ' .
-                'style="vertical-align:text-bottom; cursor:pointer;" ' .
-                'onclick="Backend.tableWizardResize(0.9);"',
-                specialchars($translator->translate('shrink.1', $defName))
-            )
-        );
-
-        $expandEvent = new GenerateHtmlEvent(
-            'magnify.gif',
-            $translator->translate('expand.0', $defName),
-            sprintf(
-                'title="%s" ' .
-                'style="vertical-align:text-bottom; cursor:pointer;" ' .
-                'onclick="Backend.tableWizardResize(1.1);"',
-                specialchars($translator->translate('expand.1', $defName))
-            )
-        );
-
-        $dispatcher->dispatch(ContaoEvents::BACKEND_ADD_TO_URL, $urlEvent);
-
-        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $importTableEvent);
-        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $shrinkEvent);
-        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $expandEvent);
-
-        return sprintf(
-            ' <a href="%s" title="%s" onclick="Backend.getScrollOffset();">%s</a> %s%s',
-            ampersand($urlEvent->getUrl()),
-            specialchars($translator->translate('importTable.1', $defName)),
-            $importTableEvent->getHtml(),
-            $shrinkEvent->getHtml(),
-            $expandEvent->getHtml()
-        );
-    }
-
-    /**
-     * Get the list import wizard.
-     *
-     * @return string
-     */
-    protected function getListWizard()
-    {
-        $environment = $this->getEnvironment();
-        $dispatcher  = $environment->getEventDispatcher();
-        $defName     = $environment->getDataDefinition()->getName();
-        $translator  = $environment->getTranslator();
-
-        $urlEvent = new AddToUrlEvent('key=list');
-
-        $importListEvent = new GenerateHtmlEvent(
-            'tablewizard.gif',
-            $translator->translate('importList.0', $defName),
-            'style="vertical-align:text-bottom;"'
-        );
-
-        $dispatcher->dispatch(ContaoEvents::BACKEND_ADD_TO_URL, $urlEvent);
-        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $importListEvent);
-
-        return sprintf(
-            ' <a href="%s" title="%s" onclick="Backend.getScrollOffset();">%s</a>',
-            ampersand($urlEvent->getUrl()),
-            specialchars($translator->translate('importList.1', $defName)),
-            $importListEvent->getHtml()
-        );
-    }
-
-    /**
-     * Get special labels.
-     *
-     * @param PropertyInterface $propInfo The property for which the X label shall be generated.
-     *
-     * @return string
-     */
-    protected function getXLabel($propInfo)
-    {
-        $xLabel      = '';
-        $environment = $this->getEnvironment();
-        $dispatcher  = $environment->getEventDispatcher();
-        $translator  = $environment->getTranslator();
-
-        // Toggle line wrap (textarea).
-        if ($propInfo->getWidgetType() === 'textarea' && !array_key_exists('rte', $propInfo->getExtra())) {
-            $event = new GenerateHtmlEvent(
-                'wrap.gif',
-                $translator->translate('wordWrap', 'MSC'),
-                sprintf(
-                    'title="%s" class="toggleWrap" onclick="Backend.toggleWrap(\'ctrl_%s\');"',
-                    specialchars($translator->translate('wordWrap', 'MSC')),
-                    $propInfo->getName()
-                )
-            );
-
-            $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $event);
-
-            $xLabel .= ' ' . $event->getHtml();
-        }
-
-        $xLabel .= $this->getHelpWizard($propInfo);
-
-        switch ($propInfo->getWidgetType()) {
-            case 'tableWizard':
-                $xLabel .= $this->getTableWizard();
-                break;
-            case 'listWizard':
-                $xLabel .= $this->getListWizard();
-                break;
-            default:
-        }
-
-        return $xLabel;
-    }
-
-    /**
      * Function for pre-loading the tiny mce.
      *
      * @return void
@@ -396,66 +207,6 @@ class ContaoWidgetManager
     }
 
     /**
-     * Get special labels.
-     *
-     * @param PropertyInterface $propInfo The property for which the X label shall be generated.
-     *
-     * @param ModelInterface    $model    The model.
-     *
-     * @return string
-     */
-    protected function getOptionsForWidget($propInfo, $model)
-    {
-        $environment = $this->getEnvironment();
-        $dispatcher  = $environment->getEventDispatcher();
-        $options     = $propInfo->getOptions();
-        $event       = new GetPropertyOptionsEvent($environment, $model);
-        $event->setPropertyName($propInfo->getName());
-        $event->setOptions($options);
-
-        $dispatcher->dispatch(
-            sprintf('%s[%s][%s]', $event::NAME, $environment->getDataDefinition()->getName(), $propInfo->getName()),
-            $event
-        );
-        $dispatcher->dispatch(sprintf('%s[%s]', $event::NAME, $environment->getDataDefinition()->getName()), $event);
-        $dispatcher->dispatch($event::NAME, $event);
-
-        if ($event->getOptions() !== $options) {
-            return $event->getOptions();
-        }
-
-        return $options;
-    }
-
-    /**
-     * Try to resolve the class name for the widget.
-     *
-     * @param PropertyInterface $property The property to get the widget class name for.
-     *
-     * @return string
-     *
-     * @SuppressWarnings(PHPMD.Superglobals)
-     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
-     */
-    protected function getWidgetClass(PropertyInterface $property)
-    {
-        if (isset($this->widgetMapping[$property->getWidgetType()])) {
-            return $this->widgetMapping[$property->getWidgetType()];
-        }
-
-        if (!isset($GLOBALS['BE_FFL'][$property->getWidgetType()])) {
-            return null;
-        }
-
-        $className = $GLOBALS['BE_FFL'][$property->getWidgetType()];
-        if (!class_exists($className)) {
-            return null;
-        }
-
-        return $className;
-    }
-
-    /**
      * Retrieve the instance of a widget for the given property.
      *
      * @param string           $property    Name of the property for which the widget shall be retrieved.
@@ -466,6 +217,9 @@ class ContaoWidgetManager
      *
      * @return \Widget
      *
+     * @throws DcGeneralRuntimeException         When No widget could be build.
+     * @throws DcGeneralInvalidArgumentException When property is not defined in the property definitions.
+     *
      * @SuppressWarnings(PHPMD.Superglobals)
      * @SuppressWarnings(PHPMD.CamelCaseVariableName)
      */
@@ -473,7 +227,6 @@ class ContaoWidgetManager
     {
         $environment         = $this->getEnvironment();
         $dispatcher          = $environment->getEventDispatcher();
-        $defName             = $environment->getDataDefinition()->getName();
         $propertyDefinitions = $environment->getDataDefinition()->getPropertiesDefinition();
 
         if (!$propertyDefinitions->hasProperty($property)) {
@@ -482,118 +235,17 @@ class ContaoWidgetManager
             );
         }
 
-        $event = new BuildWidgetEvent($environment, $this->model, $propertyDefinitions->getProperty($property));
+        $propertyDefinition = $propertyDefinitions->getProperty($property);
+        $event              = new BuildWidgetEvent($environment, $this->model, $propertyDefinition, $inputValues);
 
         $dispatcher->dispatch($event::NAME, $event);
-        if ($event->getWidget()) {
-            return $event->getWidget();
+        if (!$event->getWidget()) {
+            throw new DcGeneralRuntimeException(
+                sprintf('Widget was not build for property %s::%s.', $this->model->getProviderName(), $property)
+            );
         }
 
-        $propInfo  = $propertyDefinitions->getProperty($property);
-        $propExtra = $propInfo->getExtra();
-        $varValue  = $this->decodeValue($property, $this->model->getProperty($property));
-        $strClass  = $this->getWidgetClass($propInfo);
-
-        if ((isset($propExtra['rgxp']) && in_array($propExtra['rgxp'], array('date', 'time', 'datim')))
-            && empty($propExtra['mandatory'])
-            && is_numeric($varValue) && $varValue == 0
-        ) {
-            /*
-                FIXME TEMPORARY WORKAROUND! To be fixed in the core:
-                @see \Widget::getAttributesFromDca()
-            */
-
-            $varValue = '';
-        }
-
-        // OH: why not $required = $mandatory always? source: DataContainer 226.
-        // OH: the whole prepareForWidget(..) thing is an only mess
-        // Widgets should parse the configuration by themselves, depending on what they need.
-        $propExtra['required'] = ($varValue == '') && !empty($propExtra['mandatory']);
-
-        if ($inputValues) {
-            $values = new PropertyValueBag($inputValues->getArrayCopy());
-            $model  = clone $this->model;
-            $model->setId($this->model->getId());
-            $this->environment->getController()->updateModelFromPropertyBag($model, $values);
-        } else {
-            $model = $this->model;
-        }
-
-        $arrConfig = array(
-            'inputType' => $propInfo->getWidgetType(),
-            'label'     => array(
-                $propInfo->getLabel(),
-                $propInfo->getDescription()
-            ),
-            'options'   => $this->getOptionsForWidget($propInfo, $model),
-            'eval'      => $propExtra,
-            // TODO: populate these.
-            // 'foreignKey' => null
-        );
-
-        if (isset($propExtra['reference'])) {
-            $arrConfig['reference'] = $propExtra['reference'];
-        }
-
-        $event = new GetAttributesFromDcaEvent(
-            $arrConfig,
-            $propInfo->getName(),
-            $varValue,
-            $property,
-            $defName,
-            new DcCompat($environment, $this->model, $property)
-        );
-
-        // FIXME: propagator
-        $dispatcher->dispatch(
-            sprintf(
-                '%s[%s][%s]',
-                ContaoEvents::WIDGET_GET_ATTRIBUTES_FROM_DCA,
-                $defName,
-                $property
-            ),
-            $event
-        );
-        $dispatcher->dispatch(
-            sprintf(
-                '%s[%s]',
-                ContaoEvents::WIDGET_GET_ATTRIBUTES_FROM_DCA,
-                $defName
-            ),
-            $event
-        );
-        $dispatcher->dispatch(ContaoEvents::WIDGET_GET_ATTRIBUTES_FROM_DCA, $event);
-
-        $arrPrepared = $event->getResult();
-
-        // Bugfix CS: ajax subpalettes are really broken.
-        // Therefore we reset to the default checkbox behaviour here and submit the entire form.
-        // This way, the javascript needed by the widget (wizards) will be correctly evaluated.
-        if ($arrConfig['inputType'] == 'checkbox'
-            && isset($GLOBALS['TL_DCA'][$defName]['subpalettes'])
-            && is_array($GLOBALS['TL_DCA'][$defName]['subpalettes'])
-            && in_array($property, array_keys($GLOBALS['TL_DCA'][$defName]['subpalettes']))
-            && $arrConfig['eval']['submitOnChange']
-        ) {
-            // We have to override the onclick, do not append to it as Contao adds it's own code here in
-            // \Widget::getAttributesFromDca() which kills our sub palette handling!
-            $arrPrepared['onclick'] = "Backend.autoSubmit('" . $defName . "');";
-        }
-
-        $objWidget = new $strClass($arrPrepared, new DcCompat($environment, $this->model, $property));
-        // OH: what is this? source: DataContainer 232.
-        $objWidget->currentRecord = $this->model->getId();
-
-        $objWidget->xlabel .= $this->getXLabel($propInfo);
-
-        // FIXME: propagator
-        $event = new ManipulateWidgetEvent($environment, $this->model, $propInfo, $objWidget);
-        $dispatcher->dispatch(sprintf('%s[%s][%s]', $event::NAME, $defName, $property), $event);
-        $dispatcher->dispatch(sprintf('%s[%s]', $event::NAME, $defName), $event);
-        $dispatcher->dispatch($event::NAME, $event);
-
-        return $objWidget;
+        return $event->getWidget();
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -6,6 +6,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     Christopher Boelter <christopher@boelter.eu>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -53,6 +54,16 @@ class ContaoWidgetManager
      * @var ModelInterface
      */
     protected $model;
+
+    /**
+     * Mapping list of widget types where the DC General has it own widgets.
+     *
+     * @var array
+     */
+    protected $widgetMapping = array(
+        'fileTree'      => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTree',
+        'fileTreeOrder' => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTreeOrder'
+    );
 
     /**
      * Create a new instance.
@@ -428,6 +439,10 @@ class ContaoWidgetManager
      */
     protected function getWidgetClass(PropertyInterface $property)
     {
+        if (isset($this->widgetMapping[$property->getWidgetType()])) {
+            return $this->widgetMapping[$property->getWidgetType()];
+        }
+
         if (!isset($GLOBALS['BE_FFL'][$property->getWidgetType()])) {
             return null;
         }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -235,8 +235,16 @@ class ContaoWidgetManager
             );
         }
 
+        $model = clone $this->model;
+        $model->setId($this->model->getId());
+
+        if ($inputValues) {
+            $values = new PropertyValueBag($inputValues->getArrayCopy());
+            $this->environment->getController()->updateModelFromPropertyBag($model, $values);
+        }
+
         $propertyDefinition = $propertyDefinitions->getProperty($property);
-        $event              = new BuildWidgetEvent($environment, $this->model, $propertyDefinition, $inputValues);
+        $event              = new BuildWidgetEvent($environment, $model, $propertyDefinition);
 
         $dispatcher->dispatch($event::NAME, $event);
         if (!$event->getWidget()) {

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Event/BuildWidgetEvent.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Event/BuildWidgetEvent.php
@@ -13,6 +13,7 @@
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event;
 
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\PropertyValueBag;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
 use ContaoCommunityAlliance\DcGeneral\Event\AbstractModelAwareEvent;
@@ -46,19 +47,33 @@ class BuildWidgetEvent extends AbstractModelAwareEvent
     protected $widget;
 
     /**
+     * The input values being optionally used.
+     *
+     * @type PropertyValueBag|null
+     */
+    private $inputValues;
+
+    /**
      * Create a new event.
      *
-     * @param EnvironmentInterface $environment The environment instance in use.
+     * @param EnvironmentInterface  $environment The environment instance in use.
      *
-     * @param ModelInterface       $model       The model holding the data for the widget that shall be instantiated.
+     * @param ModelInterface        $model       The model holding the data for the widget that shall be instantiated.
      *
-     * @param PropertyInterface    $property    The property for which the widget shall be instantiated.
+     * @param PropertyInterface     $property    The property for which the widget shall be instantiated.
+     *
+     * @param PropertyValueBag|null $inputValues The input values to use (optional).
      */
-    public function __construct(EnvironmentInterface $environment, ModelInterface $model, PropertyInterface $property)
-    {
+    public function __construct(
+        EnvironmentInterface $environment,
+        ModelInterface $model,
+        PropertyInterface $property,
+        PropertyValueBag $inputValues = null
+    ) {
         parent::__construct($environment, $model);
 
-        $this->property = $property;
+        $this->property    = $property;
+        $this->inputValues = $inputValues;
     }
 
     /**
@@ -93,5 +108,15 @@ class BuildWidgetEvent extends AbstractModelAwareEvent
     public function getProperty()
     {
         return $this->property;
+    }
+
+    /**
+     * Get the input values..
+     *
+     * @return PropertyValueBag|null
+     */
+    public function getInputValues()
+    {
+        return $this->inputValues;
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Event/BuildWidgetEvent.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Event/BuildWidgetEvent.php
@@ -13,7 +13,6 @@
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event;
 
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
-use ContaoCommunityAlliance\DcGeneral\Data\PropertyValueBag;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
 use ContaoCommunityAlliance\DcGeneral\Event\AbstractModelAwareEvent;
@@ -47,13 +46,6 @@ class BuildWidgetEvent extends AbstractModelAwareEvent
     protected $widget;
 
     /**
-     * The input values being optionally used.
-     *
-     * @type PropertyValueBag|null
-     */
-    private $inputValues;
-
-    /**
      * Create a new event.
      *
      * @param EnvironmentInterface  $environment The environment instance in use.
@@ -61,19 +53,15 @@ class BuildWidgetEvent extends AbstractModelAwareEvent
      * @param ModelInterface        $model       The model holding the data for the widget that shall be instantiated.
      *
      * @param PropertyInterface     $property    The property for which the widget shall be instantiated.
-     *
-     * @param PropertyValueBag|null $inputValues The input values to use (optional).
      */
     public function __construct(
         EnvironmentInterface $environment,
         ModelInterface $model,
-        PropertyInterface $property,
-        PropertyValueBag $inputValues = null
+        PropertyInterface $property
     ) {
         parent::__construct($environment, $model);
 
-        $this->property    = $property;
-        $this->inputValues = $inputValues;
+        $this->property = $property;
     }
 
     /**
@@ -108,15 +96,5 @@ class BuildWidgetEvent extends AbstractModelAwareEvent
     public function getProperty()
     {
         return $this->property;
-    }
-
-    /**
-     * Get the input values..
-     *
-     * @return PropertyValueBag|null
-     */
-    public function getInputValues()
-    {
-        return $this->inputValues;
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
@@ -25,6 +25,7 @@ use ContaoCommunityAlliance\DcGeneral\Data\PropertyValueBag;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\EnvironmentAwareInterface;
 use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
+use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
 
 /**
  * Widget Builder build Contao backend widgets.
@@ -69,7 +70,7 @@ class WidgetBuilder implements EnvironmentAwareInterface
      */
     public static function handleEvent(BuildWidgetEvent $event)
     {
-        if ($event->getWidget()) {
+        if ($event->getWidget() || TL_MODE !== 'BE') {
             return;
         }
 
@@ -332,6 +333,8 @@ class WidgetBuilder implements EnvironmentAwareInterface
      *
      * @return \Widget
      *
+     * @throws DcGeneralRuntimeException When not running in TL_MODE BE.
+     *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
     public function buildWidget(
@@ -339,6 +342,12 @@ class WidgetBuilder implements EnvironmentAwareInterface
         ModelInterface $model,
         PropertyValueBag $inputValues = null
     ) {
+        if (TL_MODE !== 'BE') {
+            throw new DcGeneralRuntimeException(
+                sprintf('WidgetBuilder only supports TL_MODE "BE". Running in TL_MODE "%s".', TL_MODE)
+            );
+        }
+
         $environment  = $this->getEnvironment();
         $dispatcher   = $environment->getEventDispatcher();
         $propertyName = $property->getName();

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
@@ -85,13 +85,9 @@ class WidgetBuilder implements EnvironmentAwareInterface
         }
 
         $builder = new static($event->getEnvironment(), $event->getValueEncoder());
+        $widget  = $builder->buildWidget($event->getProperty(), $event->getModel(), $event->getInputValues());
 
-        try {
-            $widget = $builder->buildWidget($event->getProperty(), $event->getModel(), $event->getInputValues());
-            $event->setWidget($widget);
-        } catch (DcGeneralException $e) {
-            // Do nothing so that other subscribers can fill the gap.
-        }
+        $event->setWidget($widget);
     }
 
     /**
@@ -346,6 +342,8 @@ class WidgetBuilder implements EnvironmentAwareInterface
      * @param PropertyValueBag  $inputValues The input values to use (optional).
      *
      * @return \Widget
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
      */
     public function buildWidget(
         PropertyInterface $property,

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
@@ -44,7 +44,7 @@ class WidgetBuilder implements EnvironmentAwareInterface
     /**
      * The property value encoder.
      *
-     * @type PropertyValueEncoder
+     * @var PropertyValueEncoder
      */
     private $propertyValueEncoder;
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
@@ -1,0 +1,453 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Subscriber;
+
+use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
+use ContaoCommunityAlliance\Contao\Bindings\Events\Backend\AddToUrlEvent;
+use ContaoCommunityAlliance\Contao\Bindings\Events\Image\GenerateHtmlEvent;
+use ContaoCommunityAlliance\Contao\Bindings\Events\Widget\GetAttributesFromDcaEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\BuildWidgetEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetPropertyOptionsEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\ManipulateWidgetEvent;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\PropertyValueBag;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
+use ContaoCommunityAlliance\DcGeneral\EnvironmentAwareInterface;
+use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
+use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralException;
+
+/**
+ * Widget Builder build Contao backend widgets.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Subscriber
+ */
+class WidgetBuilder implements EnvironmentAwareInterface
+{
+    /**
+     * The environment.
+     * 
+     * @var EnvironmentInterface
+     */
+    private $environment;
+
+    /**
+     * Mapping list of widget types where the DC General has it own widgets.
+     *
+     * @var array
+     */
+    protected $widgetMapping = array(
+        'fileTree'      => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTree',
+        'fileTreeOrder' => 'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTreeOrder'
+    );
+
+    /**
+     * Construct.
+     * 
+     * @param EnvironmentInterface $environment The environment.
+     */
+    public function __construct(EnvironmentInterface $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * Handle the build widget event.
+     * 
+     * @param BuildWidgetEvent $event The event.
+     * 
+     * @return void
+     */
+    public static function handleEvent(BuildWidgetEvent $event)
+    {
+        if ($event->getWidget()) {
+            return;
+        }
+
+        $builder = new static($event->getEnvironment());
+
+        try {
+            $widget = $builder->buildWidget($event->getProperty(), $event->getModel(), $event->getInputValues());
+            $event->setWidget($widget);
+        } catch (DcGeneralException $e) {
+            // Do nothing so that other subscribers can fill the gap.
+        }
+    }
+
+    /**
+     * Retrieve the environment.
+     *
+     * @return EnvironmentInterface
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * Try to resolve the class name for the widget.
+     *
+     * @param PropertyInterface $property The property to get the widget class name for.
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
+     */
+    protected function getWidgetClass(PropertyInterface $property)
+    {
+        if (isset($this->widgetMapping[$property->getWidgetType()])) {
+            return $this->widgetMapping[$property->getWidgetType()];
+        }
+
+        if (!isset($GLOBALS['BE_FFL'][$property->getWidgetType()])) {
+            return null;
+        }
+
+        $className = $GLOBALS['BE_FFL'][$property->getWidgetType()];
+        if (!class_exists($className)) {
+            return null;
+        }
+
+        return $className;
+    }
+
+    /**
+     * Get special labels.
+     *
+     * @param PropertyInterface $propInfo The property for which the X label shall be generated.
+     *
+     * @param ModelInterface    $model    The model.
+     *
+     * @return string
+     */
+    protected function getOptionsForWidget($propInfo, $model)
+    {
+        $environment = $this->getEnvironment();
+        $dispatcher  = $environment->getEventDispatcher();
+        $options     = $propInfo->getOptions();
+        $event       = new GetPropertyOptionsEvent($environment, $model);
+        $event->setPropertyName($propInfo->getName());
+        $event->setOptions($options);
+
+        $dispatcher->dispatch(
+            sprintf('%s[%s][%s]', $event::NAME, $environment->getDataDefinition()->getName(), $propInfo->getName()),
+            $event
+        );
+        $dispatcher->dispatch(sprintf('%s[%s]', $event::NAME, $environment->getDataDefinition()->getName()), $event);
+        $dispatcher->dispatch($event::NAME, $event);
+
+        if ($event->getOptions() !== $options) {
+            return $event->getOptions();
+        }
+
+        return $options;
+    }
+
+    /**
+     * Get the table import wizard.
+     *
+     * @return string
+     */
+    protected function getTableWizard()
+    {
+        $environment = $this->getEnvironment();
+        $dispatcher  = $environment->getEventDispatcher();
+        $defName     = $environment->getDataDefinition()->getName();
+        $translator  = $environment->getTranslator();
+        $urlEvent    = new AddToUrlEvent('key=table');
+
+        $importTableEvent = new GenerateHtmlEvent(
+            'tablewizard.gif',
+            $translator->translate('importTable.0', $defName),
+            'style="vertical-align:text-bottom;"'
+        );
+
+        $shrinkEvent = new GenerateHtmlEvent(
+            'demagnify.gif',
+            $translator->translate('shrink.0', $defName),
+            sprintf(
+                'title="%s" ' .
+                'style="vertical-align:text-bottom; cursor:pointer;" ' .
+                'onclick="Backend.tableWizardResize(0.9);"',
+                specialchars($translator->translate('shrink.1', $defName))
+            )
+        );
+
+        $expandEvent = new GenerateHtmlEvent(
+            'magnify.gif',
+            $translator->translate('expand.0', $defName),
+            sprintf(
+                'title="%s" ' .
+                'style="vertical-align:text-bottom; cursor:pointer;" ' .
+                'onclick="Backend.tableWizardResize(1.1);"',
+                specialchars($translator->translate('expand.1', $defName))
+            )
+        );
+
+        $dispatcher->dispatch(ContaoEvents::BACKEND_ADD_TO_URL, $urlEvent);
+
+        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $importTableEvent);
+        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $shrinkEvent);
+        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $expandEvent);
+
+        return sprintf(
+            ' <a href="%s" title="%s" onclick="Backend.getScrollOffset();">%s</a> %s%s',
+            ampersand($urlEvent->getUrl()),
+            specialchars($translator->translate('importTable.1', $defName)),
+            $importTableEvent->getHtml(),
+            $shrinkEvent->getHtml(),
+            $expandEvent->getHtml()
+        );
+    }
+
+    /**
+     * Get the list import wizard.
+     *
+     * @return string
+     */
+    protected function getListWizard()
+    {
+        $environment = $this->getEnvironment();
+        $dispatcher  = $environment->getEventDispatcher();
+        $defName     = $environment->getDataDefinition()->getName();
+        $translator  = $environment->getTranslator();
+
+        $urlEvent = new AddToUrlEvent('key=list');
+
+        $importListEvent = new GenerateHtmlEvent(
+            'tablewizard.gif',
+            $translator->translate('importList.0', $defName),
+            'style="vertical-align:text-bottom;"'
+        );
+
+        $dispatcher->dispatch(ContaoEvents::BACKEND_ADD_TO_URL, $urlEvent);
+        $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $importListEvent);
+
+        return sprintf(
+            ' <a href="%s" title="%s" onclick="Backend.getScrollOffset();">%s</a>',
+            ampersand($urlEvent->getUrl()),
+            specialchars($translator->translate('importList.1', $defName)),
+            $importListEvent->getHtml()
+        );
+    }
+
+    /**
+     * Get special labels.
+     *
+     * @param PropertyInterface $propInfo The property for which the X label shall be generated.
+     *
+     * @return string
+     */
+    protected function getXLabel($propInfo)
+    {
+        $xLabel      = '';
+        $environment = $this->getEnvironment();
+        $dispatcher  = $environment->getEventDispatcher();
+        $translator  = $environment->getTranslator();
+
+        // Toggle line wrap (textarea).
+        if ($propInfo->getWidgetType() === 'textarea' && !array_key_exists('rte', $propInfo->getExtra())) {
+            $event = new GenerateHtmlEvent(
+                'wrap.gif',
+                $translator->translate('wordWrap', 'MSC'),
+                sprintf(
+                    'title="%s" class="toggleWrap" onclick="Backend.toggleWrap(\'ctrl_%s\');"',
+                    specialchars($translator->translate('wordWrap', 'MSC')),
+                    $propInfo->getName()
+                )
+            );
+
+            $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $event);
+
+            $xLabel .= ' ' . $event->getHtml();
+        }
+
+        $xLabel .= $this->getHelpWizard($propInfo);
+
+        switch ($propInfo->getWidgetType()) {
+            case 'tableWizard':
+                $xLabel .= $this->getTableWizard();
+                break;
+            case 'listWizard':
+                $xLabel .= $this->getListWizard();
+                break;
+            default:
+        }
+
+        return $xLabel;
+    }
+
+    /**
+     * Get the help wizard.
+     *
+     * @param PropertyInterface $propInfo The property for which the wizard shall be generated.
+     *
+     * @return string
+     */
+    protected function getHelpWizard($propInfo)
+    {
+        $helpWizard  = '';
+        $environment = $this->getEnvironment();
+        $dispatcher  = $environment->getEventDispatcher();
+        $defName     = $environment->getDataDefinition()->getName();
+        $translator  = $environment->getTranslator();
+        // Add the help wizard.
+        if ($propInfo->getExtra() && array_key_exists('helpwizard', $propInfo->getExtra())) {
+            $event = new GenerateHtmlEvent(
+                'about.gif',
+                $translator->translate('helpWizard', 'MSC'),
+                'style="vertical-align:text-bottom;"'
+            );
+
+            $dispatcher->dispatch(ContaoEvents::IMAGE_GET_HTML, $event);
+
+            $helpWizard .= sprintf(
+                ' <a href="contao/help.php?table=%s&amp;field=%s" ' .
+                'title="%s" ' .
+                'onclick="Backend.openWindow(this, 600, 500); return false;">%s</a>',
+                $defName,
+                $propInfo->getName(),
+                specialchars($translator->translate('helpWizard', 'MSC')),
+                $event->getHtml()
+            );
+        }
+
+        return $helpWizard;
+    }
+
+    /**
+     * Build a widget for a given property.
+     *
+     * @param PropertyInterface $property    The property.
+     *
+     * @param ModelInterface    $model       The current model.
+     *
+     * @param PropertyValueBag  $inputValues The input values to use (optional).
+     *
+     * @return \Widget
+     */
+    public function buildWidget(
+        PropertyInterface $property,
+        ModelInterface $model,
+        PropertyValueBag $inputValues = null
+    ) {
+        $environment  = $this->getEnvironment();
+        $dispatcher   = $environment->getEventDispatcher();
+        $propertyName = $property->getName();
+        $propExtra    = $property->getExtra();
+        $defName      = $environment->getDataDefinition()->getName();
+        // FIXME: Handle value decoding.
+        $varValue     = $this->decodeValue($propertyName, $model->getProperty($propertyName));
+        $strClass     = $this->getWidgetClass($property);
+
+        if ((isset($propExtra['rgxp']) && in_array($propExtra['rgxp'], array('date', 'time', 'datim')))
+            && empty($propExtra['mandatory'])
+            && is_numeric($varValue) && $varValue == 0
+        ) {
+            /*
+                FIXME TEMPORARY WORKAROUND! To be fixed in the core:
+                @see \Widget::getAttributesFromDca()
+            */
+
+            $varValue = '';
+        }
+
+        // OH: why not $required = $mandatory always? source: DataContainer 226.
+        // OH: the whole prepareForWidget(..) thing is an only mess
+        // Widgets should parse the configuration by themselves, depending on what they need.
+        $propExtra['required'] = ($varValue == '') && !empty($propExtra['mandatory']);
+
+        if ($inputValues) {
+            $values   = new PropertyValueBag($inputValues->getArrayCopy());
+            $newModel = clone $model;
+            $newModel->setId($model->getId());
+            $this->environment->getController()->updateModelFromPropertyBag($newModel, $values);
+            $model = $newModel;
+        }
+
+        $arrConfig = array(
+            'inputType' => $property->getWidgetType(),
+            'label'     => array(
+                $property->getLabel(),
+                $property->getDescription()
+            ),
+            'options'   => $this->getOptionsForWidget($property, $model),
+            'eval'      => $propExtra,
+            // TODO: populate these.
+            // 'foreignKey' => null
+        );
+
+        if (isset($propExtra['reference'])) {
+            $arrConfig['reference'] = $propExtra['reference'];
+        }
+
+        $event = new GetAttributesFromDcaEvent(
+            $arrConfig,
+            $property->getName(),
+            $varValue,
+            $propertyName,
+            $defName,
+            new DcCompat($environment, $model, $propertyName)
+        );
+
+        // FIXME: propagator
+        $dispatcher->dispatch(
+            sprintf(
+                '%s[%s][%s]',
+                ContaoEvents::WIDGET_GET_ATTRIBUTES_FROM_DCA,
+                $defName,
+                $propertyName
+            ),
+            $event
+        );
+        $dispatcher->dispatch(
+            sprintf(
+                '%s[%s]',
+                ContaoEvents::WIDGET_GET_ATTRIBUTES_FROM_DCA,
+                $defName
+            ),
+            $event
+        );
+        $dispatcher->dispatch(ContaoEvents::WIDGET_GET_ATTRIBUTES_FROM_DCA, $event);
+
+        $arrPrepared = $event->getResult();
+
+        // Bugfix CS: ajax subpalettes are really broken.
+        // Therefore we reset to the default checkbox behaviour here and submit the entire form.
+        // This way, the javascript needed by the widget (wizards) will be correctly evaluated.
+        if ($arrConfig['inputType'] == 'checkbox'
+            && isset($GLOBALS['TL_DCA'][$defName]['subpalettes'])
+            && is_array($GLOBALS['TL_DCA'][$defName]['subpalettes'])
+            && in_array($propertyName, array_keys($GLOBALS['TL_DCA'][$defName]['subpalettes']))
+            && $arrConfig['eval']['submitOnChange']
+        ) {
+            // We have to override the onclick, do not append to it as Contao adds it's own code here in
+            // \Widget::getAttributesFromDca() which kills our sub palette handling!
+            $arrPrepared['onclick'] = "Backend.autoSubmit('" . $defName . "');";
+        }
+
+        $objWidget = new $strClass($arrPrepared, new DcCompat($environment, $model, $propertyName));
+        // OH: what is this? source: DataContainer 232.
+        $objWidget->currentRecord = $model->getId();
+
+        $objWidget->xlabel .= $this->getXLabel($property);
+
+        // FIXME: propagator
+        $event = new ManipulateWidgetEvent($environment, $model, $property, $objWidget);
+        $dispatcher->dispatch(sprintf('%s[%s][%s]', $event::NAME, $defName, $propertyName), $event);
+        $dispatcher->dispatch(sprintf('%s[%s]', $event::NAME, $defName), $event);
+        $dispatcher->dispatch($event::NAME, $event);
+
+        return $objWidget;
+    }
+}


### PR DESCRIPTION
As discussed [here](https://github.com/contao-community-alliance/dc-general/pull/136#issuecomment-118076871) this PR extracts the widget building into an own subscriber to the BuildWidgetEvent.

It also introduce a new `PropertyValueEncoder` which extracts the encoding from the `ContaoWidgetManager`. This is done as the decoding is also required in the builder and this code is already [duplicated](https://github.com/contao-community-alliance/dc-general/blob/develop/src/ContaoCommunityAlliance/DcGeneral/Contao/Event/Subscriber.php#L148-L157).

There are still some open questions. I add them as comments to inline comments.