### PR TITLE
Always set the modelId and provider

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/IdSerializer.php
@@ -37,10 +37,8 @@ class IdSerializer extends ModelId
      */
     public function __construct($dataProviderName = '', $modelId = '')
     {
-        if (!empty($dataProviderName) && !empty($modelId)) {
-            parent::__construct($dataProviderName, $modelId);
-        }
-
+        $this->modelId          = $modelId;
+        $this->dataProviderName = $dataProviderName;
     }
 
     /**


### PR DESCRIPTION
Always set the modelId and provider no matter if anything is empty (#86, see metamodels/core#844).