### PR TITLE
Prepare clipboard to deal with model ids. 

### DIFF
--- a/contao/config/event_listeners.php
+++ b/contao/config/event_listeners.php
@@ -20,6 +20,7 @@ use ContaoCommunityAlliance\DcGeneral\Contao\Dca\Populator\HardCodedPopulator;
 use ContaoCommunityAlliance\DcGeneral\Contao\Dca\Populator\PickerCompatPopulator;
 use ContaoCommunityAlliance\DcGeneral\Contao\Subscriber\FormatModelLabelSubscriber;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler\CopyHandler;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler\CreateHandler;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler\DeleteHandler;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler\SelectHandler;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler\ToggleHandler;
@@ -71,6 +72,7 @@ return array(
         array(new GetGroupHeaderSubscriber(), 'handle')
     ),
     DcGeneralEvents::ACTION => array(
+        array(new CreateHandler(), 'handleEvent'),
         array(new SelectHandler(), 'handleEvent'),
         array(new CopyHandler(), 'handleEvent'),
         array(new DeleteHandler(), 'handleEvent'),

--- a/contao/templates/dcbe_general_clipboard.html5
+++ b/contao/templates/dcbe_general_clipboard.html5
@@ -44,7 +44,7 @@ if (count($this->options)):
     <div class="tl_listing_container" id="dcg_clipboard">
         <ul>
             <?php foreach ($this->options as $id => $row): ?>
-                <li title="ID <?php echo specialchars($item->getModelId()->getId()) ?>">
+                <li title="ID <?php echo specialchars($item->getClipboardId()) ?>">
                     <?php $item = $row['item']; ?>
                     <?php echo $icons[$item->getAction()] ?>
                     <?php echo $row['label'] ?>

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Clipboard;
+
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+
+/**
+ * {@inheritdoc}
+ */
+abstract class AbstractItem implements ItemInterface
+{
+    /**
+     * The item action.
+     *
+     * @var string
+     */
+    private $action;
+
+    /**
+     * The id of the parent model.
+     *
+     * @var ModelIdInterface
+     */
+    private $parentId;
+
+    /**
+     * Create a new instance.
+     *
+     * @param string                $action   The action being performed.
+     *
+     * @param ModelIdInterface|null $parentId The id of the parent model (null for no parent).
+     *
+     * @throws \InvalidArgumentException When the action is not one of create, cut, copy or deep copy.
+     */
+    public function __construct($action, $parentId)
+    {
+        if (
+            ItemInterface::CREATE !== $action
+            && ItemInterface::CUT !== $action
+            && ItemInterface::COPY !== $action
+            && ItemInterface::DEEP_COPY !== $action
+        ) {
+            throw new \InvalidArgumentException(
+                '$action must be one of ItemInterface::CREATE, ItemInterface::CUT or ItemInterface::COPY'
+            );
+        }
+
+        $this->action   = (string) $action;
+        $this->parentId = $parentId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCreate()
+    {
+        return ItemInterface::CREATE == $this->action;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCut()
+    {
+        return ItemInterface::CUT == $this->action;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCopy()
+    {
+        return ItemInterface::COPY == $this->action;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDeepCopy()
+    {
+        return ItemInterface::DEEP_COPY == $this->action;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParentId()
+    {
+        return $this->parentId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function equals(ItemInterface $item)
+    {
+        // It is exactly the same item
+        if ($this === $item) {
+            return true;
+        }
+
+        return !(
+            // The actions are not equal
+            $this->getAction() !== $item->getAction()
+            // One have a parent ID, the other not
+            || $this->getParentId() && !$item->getParentId()
+            || !$this->getParentId() && $item->getParentId()
+            // The parent IDs are not equal
+            || (
+                $this->getParentId()
+                && !$this->getParentId()->equals($item->getParentId())
+            )
+
+            // The model IDs are not equal
+            || !$this->getModelId()->equals($item->getModelId())
+        );
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
@@ -129,6 +129,16 @@ abstract class AbstractItem implements ItemInterface
                 && !$this->getParentId()->equals($item->getParentId())
             )
 
+            // One have a model ID, the other not
+            || $this->getModelId() && !$item->getModelId()
+            || !$this->getModelId() && $item->getModelId()
+
+            // Both has no model id.
+            || (
+                !($this->getModelId() || $item->getModelId())
+                && ($this->getDataProviderName() !== $item->getDataProviderName())
+            )
+
             // The model IDs are not equal
             || !$this->getModelId()->equals($item->getModelId())
         );

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
@@ -111,38 +111,41 @@ abstract class AbstractItem implements ItemInterface
      * {@inheritdoc}
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     public function equals(ItemInterface $item)
     {
-        // It is exactly the same item
+        // It is exactly the same item.
         if ($this === $item) {
             return true;
         }
 
-        return !(
-            // The actions are not equal
-            $this->getAction() !== $item->getAction()
-            // One have a parent ID, the other not
-            || $this->getParentId() && !$item->getParentId()
-            || !$this->getParentId() && $item->getParentId()
-            // The parent IDs are not equal
-            || (
-                $this->getParentId()
-                && !$this->getParentId()->equals($item->getParentId())
-            )
+        // The actions are not equal.
+        if ($this->getAction() !== $item->getAction()) {
+            return false;
+        }
 
-            // One have a model ID, the other not
-            || $this->getModelId() && !$item->getModelId()
-            || !$this->getModelId() && $item->getModelId()
+        // One has a parent ID, the other not.
+        if (($this->getParentId() && !$item->getParentId()) || (!$this->getParentId() && $item->getParentId())) {
+            return false;
+        }
 
-            // Both has no model id.
-            || (
-                !($this->getModelId() || $item->getModelId())
-                && ($this->getDataProviderName() !== $item->getDataProviderName())
-            )
+        // The parent IDs are not equal.
+        if ($this->getParentId() && !$this->getParentId()->equals($item->getParentId())) {
+            return false;
+        }
 
-            // The model IDs are not equal
-            || !$this->getModelId()->equals($item->getModelId())
-        );
+        // One has a model ID, the other not.
+        if (($this->getModelId() && !$item->getModelId()) || (!$this->getModelId() && $item->getModelId())) {
+            return false;
+        }
+
+        // Both have no model id and the data provider is different.
+        if (!($this->getModelId() || $item->getModelId())) {
+            return ($this->getDataProviderName() === $item->getDataProviderName());
+        }
+
+        // The model IDs are not equal
+        return $this->getModelId()->equals($item->getModelId());
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
@@ -109,6 +109,8 @@ abstract class AbstractItem implements ItemInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function equals(ItemInterface $item)
     {

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/AbstractItem.php
@@ -1,12 +1,19 @@
 <?php
 
 /**
- * PHP version 5
+ * This file is part of contao-community-alliance/dc-general.
  *
- * @package    generalDriver
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
@@ -5,6 +5,7 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -62,9 +63,9 @@ class Clipboard implements ClipboardInterface
      */
     public function push(ItemInterface $item)
     {
-        $serializedId = $item->getModelId()->getSerialized();
+        $clipboardId = $item->getClipboardId();
 
-        $this->items[$serializedId] = $item;
+        $this->items[$clipboardId] = $item;
 
         return $this;
     }
@@ -74,9 +75,9 @@ class Clipboard implements ClipboardInterface
      */
     public function remove(ItemInterface $item)
     {
-        $serializedId = $item->getModelId()->getSerialized();
+        $clipboardId = $item->getClipboardId();
 
-        unset($this->items[$serializedId]);
+        unset($this->items[$clipboardId]);
 
         return $this;
     }
@@ -86,9 +87,11 @@ class Clipboard implements ClipboardInterface
      */
     public function removeById(ModelIdInterface $modelId)
     {
-        $serializedId = $modelId->getSerialized();
-
-        unset($this->items[$serializedId]);
+        foreach ($this->items as $itemId => $item) {
+            if ($item->getModelId() && $item->getModelId()->equals($modelId)) {
+                unset($this->items[$itemId]);
+            }
+        }
 
         return $this;
     }
@@ -98,13 +101,13 @@ class Clipboard implements ClipboardInterface
      */
     public function has(ItemInterface $item)
     {
-        $serializedId = $item->getModelId()->getSerialized();
+        $clipboardId = $item->getClipboardId();
 
-        if (!isset($this->items[$serializedId])) {
+        if (!isset($this->items[$clipboardId])) {
             return false;
         }
 
-        $existingItem = $this->items[$serializedId];
+        $existingItem = $this->items[$clipboardId];
 
         return $existingItem->equals($item);
     }
@@ -114,9 +117,13 @@ class Clipboard implements ClipboardInterface
      */
     public function hasId(ModelIdInterface $modelId)
     {
-        $serializedId = $modelId->getSerialized();
+        foreach ($this->items as $item) {
+            if ($item->getModelId() && $item->getModelId()->equals($modelId)) {
+                return true;
+            }
+        }
 
-        return isset($this->items[$serializedId]);
+        return false;
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
@@ -99,6 +99,16 @@ class Clipboard implements ClipboardInterface
     /**
      * {@inheritDoc}
      */
+    public function removeByClipboardId($clipboardId)
+    {
+        unset($this->items[$clipboardId]);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function has(ItemInterface $item)
     {
         $clipboardId = $item->getClipboardId();

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
@@ -25,7 +25,7 @@ use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
 class Clipboard implements ClipboardInterface
 {
     /**
-     * The item collection.
+     * The item collection (indexed by clipboard ids).
      *
      * @var ItemInterface[]
      */

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Clipboard.php
@@ -50,7 +50,7 @@ class Clipboard implements ClipboardInterface
             $this->items = unserialize(base64_decode($data));
             foreach ($this->items as $item) {
                 if ($item->getModelId()) {
-                    $this->itemsByModelId[$item->getModelId()->getSerialized()] = $item;
+                    $this->itemsByModelId[$item->getClipboardId()] = $item;
                 }
             }
         }

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ClipboardInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ClipboardInterface.php
@@ -73,6 +73,15 @@ interface ClipboardInterface
     public function removeById(ModelIdInterface $modelId);
 
     /**
+     * Remove an item from the clipboard by its clipboard id.
+     *
+     * @param string $clipboardId The clipboard id.
+     *
+     * @return static
+     */
+    public function removeByClipboardId($clipboardId);
+
+    /**
      * Determine if an item exist.
      *
      * @param ItemInterface $item The item.

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ClipboardInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ClipboardInterface.php
@@ -5,6 +5,7 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ClipboardInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ClipboardInterface.php
@@ -49,6 +49,8 @@ interface ClipboardInterface
     /**
      * Push an item to the clipboard.
      *
+     * If an instance with the same clipboard id has already been added it will get overwritten.
+     *
      * @param ItemInterface $item The item.
      *
      * @return static

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
@@ -43,15 +43,13 @@ class Filter implements FilterInterface
 
     const MODEL_IS_FROM_PROVIDER_EXPRESSION = <<<'EXPR'
 (
-    item.getModelId()
-    and item.getModelId().getDataProviderName() === variables[%d]
+    item.getDataProviderName() === variables[%d]
 )
 EXPR;
 
     const MODEL_IS_NOT_FROM_PROVIDER_EXPRESSION = <<<'EXPR'
 (
-    item.getModelId()
-    and item.getModelId().getDataProviderName() !== variables[%d]
+    item.getDataProviderName() !== variables[%d]
 )
 EXPR;
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
@@ -55,13 +55,15 @@ EXPR;
 
     const MODEL_IS_EXPRESSION = <<<'EXPR'
 (
-    item.getModelId().equals(variables[%d])
+    item.getModelId()
+    and item.getModelId().equals(variables[%d])
 )
 EXPR;
 
     const MODEL_IS_NOT_EXPRESSION = <<<'EXPR'
 (
-    !item.getModelId().equals(variables[%d])
+    !item.getModelId()
+    or !item.getModelId().equals(variables[%d])
 )
 EXPR;
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
@@ -876,7 +876,7 @@ EXPR;
             $expression[]      = sprintf(self::ACTION_IS_NOT_EXPRESSION, $index);
             $this->variables[] = $action;
         }
-        $this->expression[] = '(' . implode(' or ', $expression) . ')';
+        $this->expression[] = '(' . implode(' and ', $expression) . ')';
         $this->compiled     = null;
 
         return $this;

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
@@ -96,8 +96,8 @@ EXPR;
 
     const PARENT_IS_NOT_EXPRESSION = <<<'EXPR'
 (
-    item.getParentId()
-    and !item.getParentId().equals(variables[%d])
+    !item.getParentId()
+    or !item.getParentId().equals(variables[%d])
 )
 EXPR;
 
@@ -668,7 +668,7 @@ EXPR;
             $expression[]      = sprintf(self::PARENT_IS_NOT_EXPRESSION, $index);
             $this->variables[] = $parentModelId;
         }
-        $this->expression[] = '(' . implode(' or ', $expression) . ')';
+        $this->expression[] = '(' . implode(' and ', $expression) . ')';
         $this->compiled     = null;
 
         return $this;

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Filter.php
@@ -113,6 +113,13 @@ EXPR;
 )
 EXPR;
 
+    const SUB_FILTER = <<<'EXPR'
+(
+    variables[%d].accepts(item)
+)
+EXPR;
+
+
     /**
      * Factory method.
      *
@@ -885,11 +892,11 @@ EXPR;
     /**
      * And sub filter.
      *
-     * @param Filter $filter The sub filter.
+     * @param FilterInterface $filter The sub filter.
      *
      * @return static
      */
-    public function andSub(Filter $filter)
+    public function andSub(FilterInterface $filter)
     {
         $this->sub('and', $filter);
 
@@ -899,11 +906,11 @@ EXPR;
     /**
      * Or sub filter.
      *
-     * @param Filter $filter The sub filter.
+     * @param FilterInterface $filter The sub filter.
      *
      * @return static
      */
-    public function orSub(Filter $filter)
+    public function orSub(FilterInterface $filter)
     {
         $this->sub('or', $filter);
 
@@ -913,25 +920,21 @@ EXPR;
     /**
      * Add sub filter.
      *
-     * @param string $conjunction AND or OR.
-     * @param Filter $filter      The sub filter.
+     * @param string          $conjunction AND or OR.
+     * @param FilterInterface $filter      The sub filter.
      *
      * @return static
      */
-    private function sub($conjunction, Filter $filter)
+    private function sub($conjunction, FilterInterface $filter)
     {
         if (!empty($this->expression)) {
             $this->expression[] = $conjunction;
         }
 
-        $expression = $filter->getExpression();
-        $variables  = $filter->getVariables();
-
-        $index      = count($this->variables);
-        $expression = str_replace('variables', 'variables[' . $index . ']', $expression);
-
-        $this->expression[] = '(' . $expression . ')';
-        $this->variables[]  = $variables;
+        $index              = count($this->variables);
+        $this->expression[] = sprintf(self::SUB_FILTER, $index);
+        $this->variables[]  = $filter;
+        $this->compiled     = null;
 
         return $this;
     }

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
@@ -71,6 +71,8 @@ class Item extends AbstractItem
      */
     public function getClipboardId()
     {
-        return $this->modelId->getSerialized();
+        return $this->getAction() .
+            ($this->modelId ? $this->modelId->getSerialized() : 'null') .
+            (($parentId = $this->getParentId()) ? $parentId->getSerialized() : 'null');
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
@@ -61,9 +61,9 @@ class Item extends AbstractItem
     /**
      * {@inheritdoc}
      */
-    public function getProviderName()
+    public function getDataProviderName()
     {
-        return $this->modelId->getProviderName();
+        return $this->modelId->getDataProviderName();
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
@@ -6,6 +6,7 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -130,6 +131,14 @@ class Item implements ItemInterface
     public function getModelId()
     {
         return $this->modelId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClipboardId()
+    {
+        return $this->modelId->getSerialized();
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/Item.php
@@ -19,22 +19,8 @@ use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
 /**
  * {@inheritdoc}
  */
-class Item implements ItemInterface
+class Item extends AbstractItem
 {
-    /**
-     * The item action.
-     *
-     * @var string
-     */
-    private $action;
-
-    /**
-     * The id of the parent model.
-     *
-     * @var ModelIdInterface
-     */
-    private $parentId;
-
     /**
      * The id of the model.
      *
@@ -55,74 +41,13 @@ class Item implements ItemInterface
      */
     public function __construct($action, $parentId, $modelId)
     {
-        if (
-            ItemInterface::CREATE !== $action
-            && ItemInterface::CUT !== $action
-            && ItemInterface::COPY !== $action
-            && ItemInterface::DEEP_COPY !== $action
-        ) {
-            throw new \InvalidArgumentException(
-                '$action must be one of ItemInterface::CREATE, ItemInterface::CUT or ItemInterface::COPY'
-            );
+        parent::__construct($action, $parentId);
+
+        if (!$modelId instanceof ModelIdInterface) {
+            throw new \InvalidArgumentException('Invalid $modelId given.');
         }
 
-        if (null === $modelId && $action !== ItemInterface::CREATE) {
-            throw new \InvalidArgumentException(
-                '$modelId must be valid unless in create action.'
-            );
-        }
-
-        $this->action   = (string) $action;
-        $this->parentId = $parentId;
-        $this->modelId  = $modelId;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAction()
-    {
-        return $this->action;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isCreate()
-    {
-        return ItemInterface::CREATE == $this->action;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isCut()
-    {
-        return ItemInterface::CUT == $this->action;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isCopy()
-    {
-        return ItemInterface::COPY == $this->action;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isDeepCopy()
-    {
-        return ItemInterface::DEEP_COPY == $this->action;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParentId()
-    {
-        return $this->parentId;
+        $this->modelId = $modelId;
     }
 
     /**
@@ -136,34 +61,16 @@ class Item implements ItemInterface
     /**
      * {@inheritdoc}
      */
-    public function getClipboardId()
+    public function getProviderName()
     {
-        return $this->modelId->getSerialized();
+        return $this->modelId->getProviderName();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function equals(ItemInterface $item)
+    public function getClipboardId()
     {
-        // It is exactly the same item
-        if ($this === $item) {
-            return true;
-        }
-
-        return !(
-            // The actions are not equal
-            $this->getAction() !== $item->getAction()
-            // One have a parent ID, the other not
-            || $this->getParentId() && !$item->getParentId()
-            || !$this->getParentId() && $item->getParentId()
-            // The parent IDs are not equal
-            || (
-                $this->getParentId()
-                && !$this->getParentId()->equals($item->getParentId())
-            )
-            // The model IDs are not equal
-            || !$this->getModelId()->equals($item->getModelId())
-        );
+        return $this->modelId->getSerialized();
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ItemInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ItemInterface.php
@@ -101,7 +101,7 @@ interface ItemInterface
      *
      * @return string
      */
-    public function getProviderName();
+    public function getDataProviderName();
 
     /**
      * Get the id which identifies the item in the clipboard.

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ItemInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ItemInterface.php
@@ -97,6 +97,13 @@ interface ItemInterface
     public function getModelId();
 
     /**
+     * Retrieve the provider name of the model from this item.
+     *
+     * @return string
+     */
+    public function getProviderName();
+
+    /**
      * Get the id which identifies the item in the clipboard.
      *
      * @return string

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ItemInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/ItemInterface.php
@@ -6,6 +6,7 @@
  * @package    generalDriver
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The MetaModels team.
  * @license    LGPL.
  * @filesource
@@ -19,6 +20,8 @@ use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
  * Interface ItemInterface.
  *
  * A single clipboard action item.
+ *
+ * The item is designed to be immutable! A mutable implementation would probably leads to unexpected behaviour.
  *
  * @package DcGeneral\Clipboard
  */
@@ -92,6 +95,13 @@ interface ItemInterface
      * @return ModelId|null
      */
     public function getModelId();
+
+    /**
+     * Get the id which identifies the item in the clipboard.
+     *
+     * @return string
+     */
+    public function getClipboardId();
 
     /**
      * Determine if this item, is equals to the other item.

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
@@ -61,7 +61,7 @@ class UnsavedItem extends AbstractItem
     /**
      * {@inheritdoc}
      */
-    public function getProviderName()
+    public function getDataProviderName()
     {
         return $this->providerName;
     }
@@ -71,6 +71,6 @@ class UnsavedItem extends AbstractItem
      */
     public function getClipboardId()
     {
-        return $this->getProviderName();
+        return $this->getDataProviderName();
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
@@ -71,6 +71,8 @@ class UnsavedItem extends AbstractItem
      */
     public function getClipboardId()
     {
-        return $this->getDataProviderName();
+        return $this->getAction() .
+            $this->getDataProviderName() .
+            (($parentId = $this->getParentId()) ? $parentId->getSerialized() : 'null');
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
@@ -24,7 +24,7 @@ class UnsavedItem extends AbstractItem
     /**
      * The provider name.
      *
-     * @type string
+     * @var string
      */
     private $providerName;
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Clipboard;
+
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+
+/**
+ * UnsavedItem is designed for new items being created which does not have an id yet.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Clipboard
+ */
+class UnsavedItem extends AbstractItem
+{
+    /**
+     * The provider name.
+     *
+     * @type string
+     */
+    private $providerName;
+
+    /**
+     * Create a new instance.
+     *
+     * @param string                $action       The action being performed.
+     *
+     * @param ModelIdInterface|null $parentId     The id of the parent model (null for no parent).
+     *
+     * @param string                $providerName The provider name of the item being created.
+     *
+     * @throws \InvalidArgumentException When the action is not create.
+     */
+    public function __construct($action, $parentId, $providerName)
+    {
+        parent::__construct($action, $parentId);
+
+        if ($action !== ItemInterface::CREATE) {
+            throw new \InvalidArgumentException('UnsavedItem is designed for create actions only.');
+        }
+
+        $this->providerName = $providerName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getModelId()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProviderName()
+    {
+        return $this->providerName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClipboardId()
+    {
+        return $this->getProviderName();
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Clipboard/UnsavedItem.php
@@ -1,12 +1,19 @@
 <?php
 
 /**
- * PHP version 5
+ * This file is part of contao-community-alliance/dc-general.
  *
- * @package    generalDriver
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ActionHandler/CreateHandler.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ActionHandler/CreateHandler.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler;
+
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EditMask;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ViewHelpers;
+/**
+ * Class CreateHandler
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler
+ */
+class CreateHandler extends AbstractHandler
+{
+    /**
+     * Handle the action.
+     *
+     * @return void
+     */
+    public function process()
+    {
+        $environment   = $this->getEnvironment();
+        $inputProvider = $environment->getInputProvider();
+        $event         = $this->getEvent();
+        $action        = $event->getAction();
+
+        // Only handle if we does not have a manual sorting or we know where to insert.
+        // Manual sorting is handled by clipboard.
+        if ($action->getName() !== 'create'
+            || (ViewHelpers::getManualSortingProperty($environment) && !$inputProvider->hasParameter('after'))) {
+            return;
+        }
+
+        $dataProvider = $environment->getDataProvider();
+        $model        = $dataProvider->getEmptyModel();
+        $clone        = $dataProvider->getEmptyModel();
+
+        $view = $environment->getView();
+        if (!$view instanceof BaseView) {
+            return;
+        }
+
+        $editMask = new EditMask($view, $model, $clone, null, null, $view->breadcrumb());
+        $event->setResponse($editMask->execute());
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
@@ -1409,7 +1409,7 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
      * @SuppressWarnings(PHPMD.Superglobals)
      * @SuppressWarnings(PHPMD.CamelCaseVariableName)
      */
-    protected function breadcrumb()
+    public function breadcrumb()
     {
         $event = new GetBreadcrumbEvent($this->getEnvironment());
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
@@ -690,15 +690,6 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
 
         // Add new button.
         if (
-            ($mode == BasicDefinitionInterface::MODE_FLAT)
-            || (($mode == BasicDefinitionInterface::MODE_PARENTEDLIST) && !$manualSorting)
-        ) {
-            $parameters['act'] = 'edit';
-            // Add new button.
-            if ($pid) {
-                $parameters['pid'] = $pid->getSerialized();
-            }
-        } elseif (
             ($mode == BasicDefinitionInterface::MODE_PARENTEDLIST)
             || ($mode == BasicDefinitionInterface::MODE_HIERARCHICAL)
         ) {
@@ -713,12 +704,12 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
             if ($environment->getClipboard()->isNotEmpty($filter)) {
                 return null;
             }
+        }
 
-            $parameters['act'] = 'create';
-
-            if ($pid) {
-                $parameters['pid'] = $pid->getSerialized();
-            }
+        $parameters['act'] = 'create';
+        // Add new button.
+        if ($pid) {
+            $parameters['pid'] = $pid->getSerialized();
         }
 
         return $command;

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
@@ -216,11 +216,10 @@ class ClipboardController implements EventSubscriberInterface
 
         $options = array();
         foreach ($clipboard->fetch($filter) as $item) {
-            $modelId           = $item->getModelId();
-            $serializedModelId = $modelId->getSerialized();
-            $dataProvider      = $environment->getDataProvider($modelId->getDataProviderName());
+            $modelId      = $item->getModelId();
+            $dataProvider = $environment->getDataProvider($item->getDataProviderName());
 
-            if ($modelId->getId()) {
+            if ($modelId) {
                 $config = $dataProvider->getEmptyConfig();
                 $config->setId($modelId->getId());
                 $model = $dataProvider->fetch($config);
@@ -240,7 +239,7 @@ class ClipboardController implements EventSubscriberInterface
                 $label = $environment->getTranslator()->translate('new.0', $modelId->getDataProviderName());
             }
 
-            $options[$serializedModelId] = array(
+            $options[$item->getClipboardId()] = array(
                 'item'  => $item,
                 'model' => $model,
                 'label' => $label,

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
@@ -20,7 +20,6 @@ use ContaoCommunityAlliance\DcGeneral\Clipboard\Filter;
 use ContaoCommunityAlliance\DcGeneral\Clipboard\Item;
 use ContaoCommunityAlliance\DcGeneral\Clipboard\ItemInterface;
 use ContaoCommunityAlliance\DcGeneral\Clipboard\UnsavedItem;
-use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\IdSerializer;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ViewHelpers;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\DcGeneralEvents;
@@ -84,11 +83,10 @@ class ClipboardController implements EventSubscriberInterface
         $eventDispatcher = $environment->getEventDispatcher();
         $clipboard       = $environment->getClipboard();
         $input           = $environment->getInputProvider();
-        $modelId         = $input->getParameter('clipboard-item');
+        $clipboardId     = $input->getParameter('clipboard-item');
 
-        if ($modelId) {
-            $modelId = IdSerializer::fromSerialized($modelId);
-            $clipboard->removeById($modelId);
+        if ($clipboardId) {
+            $clipboard->removeByClipboardId($clipboardId);
         } else {
             $clipboard->clear();
         }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
@@ -150,6 +150,11 @@ class ClipboardController implements EventSubscriberInterface
         }
 
         if ('create' === $actionName) {
+            // No manual sorting property defined, no need to add it to the clipboard.
+            if (!ViewHelpers::getManualSortingProperty($environment)) {
+                return;
+            }
+
             $providerName = $environment->getDataDefinition()->getBasicDefinition()->getDataProvider();
             $item         = new UnsavedItem($clipboardActionName, $parentId, $providerName);
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
@@ -234,7 +234,7 @@ class ClipboardController implements EventSubscriberInterface
                 $label = $label['content'];
             } else {
                 $model = $dataProvider->getEmptyModel();
-                $label = $environment->getTranslator()->translate('new.0', $modelId->getDataProviderName());
+                $label = $environment->getTranslator()->translate('new.0', $item->getDataProviderName());
             }
 
             $options[$item->getClipboardId()] = array(

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Controller/ClipboardController.php
@@ -150,8 +150,11 @@ class ClipboardController implements EventSubscriberInterface
         }
 
         if ('create' === $actionName) {
+            $inputProvider = $environment->getInputProvider();
+
             // No manual sorting property defined, no need to add it to the clipboard.
-            if (!ViewHelpers::getManualSortingProperty($environment)) {
+            // Or we already have an after attribute, a handler can pick it up.
+            if (!ViewHelpers::getManualSortingProperty($environment) || $inputProvider->hasParameter('after')) {
                 return;
             }
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/ControllerInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/ControllerInterface.php
@@ -160,7 +160,7 @@ interface ControllerInterface
      *
      * @param ItemInterface $item The clipboard item.
      *
-     * @return ModelInterface
+     * @return ModelInterface|null
      */
     public function getModelFromClipboardItem(ItemInterface $item);
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
@@ -572,7 +572,12 @@ class DefaultController implements ControllerInterface
      */
     public function getModelFromClipboardItem(ItemInterface $item)
     {
-        $modelId      = $item->getModelId();
+        $modelId = $item->getModelId();
+
+        if (!$modelId) {
+            return null;
+        }
+
         $environment  = $this->getEnvironment();
         $dataProvider = $environment->getDataProvider($modelId->getDataProviderName());
         $config       = $dataProvider->getEmptyConfig()->setId($modelId->getId());
@@ -592,11 +597,15 @@ class DefaultController implements ControllerInterface
         foreach ($items as $item) {
             /** @var ItemInterface $item */
             $modelId      = $item->getModelId();
-            $dataProvider = $environment->getDataProvider($modelId->getDataProviderName());
-            // FIXME: Item should allow null as modelId so we can skip the second check here and move to class ModelId.
-            if ($modelId && $modelId->getId()) {
-                $models->push($dataProvider->fetch($dataProvider->getEmptyConfig()->setId($modelId->getId())));
+            $dataProvider = $environment->getDataProvider($item->getDataProviderName());
 
+            if ($modelId) {
+                $model = $dataProvider->fetch($dataProvider->getEmptyConfig()->setId($modelId->getId()));
+
+                // Make sure model exists.
+                if ($model) {
+                    $models->push($model);
+                }
                 continue;
             }
 
@@ -708,11 +717,11 @@ class DefaultController implements ControllerInterface
         $actions     = array();
 
         foreach ($items as $item) {
-            if ($item->isCreate()) {
-                $model = null;
-            } else {
+            $model = null;
+
+            if (!$item->isCreate() && $item->getModelId()) {
                 $modelId      = $item->getModelId();
-                $dataProvider = $environment->getDataProvider($modelId->getDataProviderName());
+                $dataProvider = $environment->getDataProvider($item->getDataProviderName());
                 $config       = $dataProvider->getEmptyConfig()->setId($modelId->getId());
                 $model        = $dataProvider->fetch($config);
             }

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ClipboardTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ClipboardTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
+
+use ContaoCommunityAlliance\DcGeneral\Clipboard\Clipboard;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\Filter;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\Item;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\UnsavedItem;
+use ContaoCommunityAlliance\DcGeneral\DefaultEnvironment;
+use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
+
+/**
+ * This class tests the clipboard.
+ */
+class ClipboardTest extends TestCase
+{
+    /**
+     * Mocks the environment with session storage.
+     *
+     * @return DefaultEnvironment
+     */
+    private function mockEnvironment()
+    {
+        $environment = new DefaultEnvironment();
+        $environment->setSessionStorage(new MockedSessionStorage());
+
+        return $environment;
+    }
+
+    /**
+     * Test various operations.
+     *
+     * @return void
+     */
+    public function testAll()
+    {
+        $environment = $this->mockEnvironment();
+
+        $clipboard    = new Clipboard();
+        $filterGetAll = new Filter();
+        $createItem   = new UnsavedItem(Item::CREATE, null, 'dummy-provider');
+
+        $this->assertTrue($clipboard->isEmpty($filterGetAll));
+        $this->assertFalse($clipboard->isNotEmpty($filterGetAll));
+
+        $clipboard->push($createItem);
+        $this->assertFalse($clipboard->isEmpty($filterGetAll));
+        $this->assertTrue($clipboard->isNotEmpty($filterGetAll));
+
+        $this->assertTrue($clipboard->has($createItem));
+        $this->assertTrue($clipboard->has(clone $createItem));
+
+        $clipboard2 = new Clipboard();
+        $clipboard->saveTo($environment);
+        $clipboard2->loadFrom($environment);
+
+        $this->assertTrue($clipboard2->has($createItem));
+        $this->assertTrue($clipboard2->has(clone $createItem));
+    }
+}

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ClipboardTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ClipboardTest.php
@@ -1,11 +1,20 @@
 <?php
+
 /**
- * PHP version 5
+ * This file is part of contao-community-alliance/dc-general.
  *
- * @package    generalDriver
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
@@ -12,6 +12,7 @@
 namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
 
 use ContaoCommunityAlliance\DcGeneral\Clipboard\Filter;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\FilterInterface;
 use ContaoCommunityAlliance\DcGeneral\Clipboard\ItemInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
@@ -488,7 +489,7 @@ class FilterTest extends TestCase
 
 
     /**
-     * Test andModelIs filter.
+     * Test andParentIsNotFromProvider filter.
      *
      * @dataProvider provideForModelIsNotFromDataProvider()
      */
@@ -498,6 +499,112 @@ class FilterTest extends TestCase
         $item   = new MockedAbstractItem(ItemInterface::CREATE, new ModelId($provider1, 3), null);
 
         $filter->andParentIsNotFromProvider($provider2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Test orParentIsNotFromProvider filter.
+     *
+     * @dataProvider provideForModelIsNotFromDataProvider()
+     */
+    public function testOrParentIsNotFromProvider($expected, $provider1, $provider2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, new ModelId($provider1, 3), null);
+
+        $filter->orParentIsNotFromProvider($provider2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Test testAndParentIsIn filter.
+     *
+     * @dataProvider provideParents()
+     */
+    public function testAndParentIsIn($expected, $parentId1, $parentId2, $parentId3)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
+
+        $filter->andParentIsIn([$parentId2, $parentId3]);
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Test testAndParentIsIn filter.
+     *
+     * @dataProvider provideParents()
+     */
+    public function testParentIsNotIn($expected, $parentId1, $parentId2, $parentId3)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
+
+        $filter->andParentIsNotIn([$parentId2, $parentId3]);
+        $this->assertEquals(!$expected, $filter->accepts($item));
+    }
+
+    /**
+     * Test testAndParentIsIn filter.
+     *
+     * @dataProvider provideParents()
+     */
+    public function testOrParentIsIn($expected, $parentId1, $parentId2, $parentId3)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
+
+        $filter->andParentIsIn([$parentId2, $parentId3]);
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Provide sub filter test values.
+     *
+     * @return array
+     */
+    public function provideSubFilter()
+    {
+        return array(
+            array(true, new MockedFilter(true)),
+            array(false, new MockedFilter(false))
+        );
+    }
+
+    /**
+     * Test and sub filter.
+     *
+     * @dataProvider provideSubFilter()
+     */
+    public function testAndSub($expected, FilterInterface $subFilter)
+    {
+        $item   = new MockedAbstractItem(ItemInterface::CREATE);
+
+        $firstSub = new MockedFilter(true);
+        $filter   = new Filter();
+
+        $filter->andSub($firstSub);
+        $filter->andSub($subFilter);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Test and sub filter.
+     *
+     * @dataProvider provideSubFilter()
+     */
+    public function testOrSub($expected, FilterInterface $subFilter)
+    {
+        $item   = new MockedAbstractItem(ItemInterface::CREATE);
+
+        $firstSub = new MockedFilter(false);
+        $filter   = new Filter();
+
+        $filter->orSub($firstSub);
+        $filter->orSub($subFilter);
 
         $this->assertEquals($expected, $filter->accepts($item));
     }

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
@@ -1,22 +1,26 @@
 <?php
-
 /**
- * @package    westwerk
- * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2015 netzmacht creative David Molineus
- * @license    LGPL 3.0
- * @filesource
+ * PHP version 5
  *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
  */
 
 namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
-
 
 use ContaoCommunityAlliance\DcGeneral\Clipboard\Filter;
 use ContaoCommunityAlliance\DcGeneral\Clipboard\ItemInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
 
+/**
+ * Test for the Filter.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Test\ClipBoard
+ */
 class FilterTest extends TestCase
 {
     /**

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
@@ -1,0 +1,500 @@
+<?php
+
+/**
+ * @package    westwerk
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2015 netzmacht creative David Molineus
+ * @license    LGPL 3.0
+ * @filesource
+ *
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
+
+
+use ContaoCommunityAlliance\DcGeneral\Clipboard\Filter;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\ItemInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
+use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
+
+class FilterTest extends TestCase
+{
+    /**
+     * Provide an action matrix with 3 different actions per row.
+     *
+     * @return array
+     */
+    public function provideActions()
+    {
+        return array(
+            array(ItemInterface::CREATE, ItemInterface::COPY, ItemInterface::CUT),
+            array(ItemInterface::COPY, ItemInterface::CREATE, ItemInterface::DEEP_COPY),
+            array(ItemInterface::DEEP_COPY, ItemInterface::COPY, ItemInterface::CREATE),
+            array(ItemInterface::CREATE, ItemInterface::COPY, ItemInterface::CUT),
+            array(ItemInterface::CUT, ItemInterface::COPY, ItemInterface::CREATE),
+        );
+    }
+
+    /**
+     * Test andActionIs filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testAndActionIs($action1, $action2)
+    {
+        $filter = new Filter();
+        $filter->andActionIs($action1);
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(true, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(false, $filter->accepts($item2));
+    }
+
+    /**
+     * Test andActionIsNot filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testAndActionIsNot($action1, $action2)
+    {
+        $filter = new Filter();
+        $filter->andActionIsNot($action1);
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(false, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(true, $filter->accepts($item2));
+    }
+
+    /**
+     * Test orActionIs filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testOrActionIs($action1, $action2, $action3)
+    {
+        $filter = new Filter();
+        $filter->orActionIs($action1)->orActionIs($action2);
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(true, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(true, $filter->accepts($item2));
+
+        $item3 = new MockedAbstractItem($action3);
+        $this->assertEquals(false, $filter->accepts($item3));
+    }
+
+    /**
+     * Test orActionIsNot filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testOrActionIsNot($action1, $action2, $action3)
+    {
+        $filter = new Filter();
+        $filter->orActionIsNot($action1);
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(false, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(true, $filter->accepts($item2));
+
+        $item3 = new MockedAbstractItem($action3);
+        $this->assertEquals(true, $filter->accepts($item3));
+    }
+
+    /**
+     * Test andActionIsIn filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testAndActionIsIn($action1, $action2, $action3)
+    {
+        $filter = new Filter();
+        $filter->andActionIsIn(array($action1));
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(true, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(false, $filter->accepts($item2));
+
+        $item3 = new MockedAbstractItem($action3);
+        $this->assertEquals(false, $filter->accepts($item3));
+    }
+
+    /**
+     * Test andActionIsNotIn filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testAndActionIsNotIn($action1, $action2, $action3)
+    {
+        $filter = new Filter();
+        $filter->andActionIsNotIn(array($action1, $action2));
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(false, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(false, $filter->accepts($item2));
+
+        $item3 = new MockedAbstractItem($action3);
+        $this->assertEquals(true, $filter->accepts($item3));
+    }
+
+    /**
+     * Test andActionIsIn filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testOrActionIsIn($action1, $action2, $action3)
+    {
+        $filter = new Filter();
+        $filter->andActionIsIn(array($action1));
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(true, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(false, $filter->accepts($item2));
+
+        $item3 = new MockedAbstractItem($action3);
+        $this->assertEquals(false, $filter->accepts($item3));
+    }
+
+    /**
+     * Test orActionIsNotIn filter.
+     *
+     * @dataProvider provideActions()
+     */
+    public function testOrActionIsNotIn($action1, $action2, $action3)
+    {
+        $filter = new Filter();
+        $filter
+            ->orActionIsNotIn(array($action1))
+            ->orActionIsNotIn(array($action1, $action2));
+
+        $item = new MockedAbstractItem($action1);
+        $this->assertEquals(false, $filter->accepts($item));
+
+        $item2 = new MockedAbstractItem($action2);
+        $this->assertEquals(true, $filter->accepts($item2));
+
+        $item3 = new MockedAbstractItem($action3);
+        $this->assertEquals(true, $filter->accepts($item3));
+    }
+
+    /**
+     * Test andHasNoParent filter.
+     */
+    public function testAndHasNoParent()
+    {
+        $filter = new Filter();
+
+        $parentId = new ModelId('dummy-provider', 5);
+        $item     = new MockedAbstractItem(ItemInterface::CREATE, $parentId);
+        $item2    = new MockedAbstractItem(ItemInterface::CREATE);
+
+        $filter->andHasNoParent();
+
+        $this->assertEquals(false, $filter->accepts($item));
+        $this->assertEquals(true, $filter->accepts($item2));
+    }
+
+    /**
+     * Test orHasNoParent filter.
+     */
+    public function testOrHasNoParent()
+    {
+        $filter = new Filter();
+
+        $parentId = new ModelId('dummy-provider', 5);
+        $item     = new MockedAbstractItem(ItemInterface::CREATE, $parentId);
+        $item2    = new MockedAbstractItem(ItemInterface::CREATE);
+
+        $filter->orHasNoParent();
+
+        $this->assertEquals(false, $filter->accepts($item));
+        $this->assertEquals(true, $filter->accepts($item2));
+    }
+
+    /**
+     * Provide test matrix for testOrParentIs and testAndParentIs.
+     *
+     * @return array
+     */
+    public function provideParents()
+    {
+        $parentId1 = new ModelId('dummy-provider', 4);
+        $parentId2 = new ModelId('dummy-provider', 5);
+        $parentId3 = new ModelId('dummy-provider', 6);
+
+        return array(
+            array(true, $parentId1, $parentId1, $parentId3),
+            array(false, $parentId1, $parentId2, $parentId3),
+            array(false, null, $parentId2, $parentId3),
+        );
+    }
+
+    /**
+     * Test orParentIs filter.
+     *
+     * @dataProvider provideParents()
+     */
+    public function testOrParentIs($expected, $parentId1, $parentId2, $parentId3)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
+
+        $filter->orParentIs($parentId2)->orParentIs($parentId3);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Test orParentIs filter.
+     *
+     * @dataProvider provideParents()
+     */
+    public function testAndParentIs($expected, $parentId1, $parentId2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
+
+        $filter->andParentIs($parentId2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Provide test matrix for testAndModelIdIs.
+     *
+     * @return array
+     */
+    public function provideForAndModelIdIs()
+    {
+        $modelId1 = new ModelId('dummy-provider', 4);
+        $modelId2 = new ModelId('dummy-provider', 5);
+
+        return array(
+            array(true, $modelId1, $modelId1),
+            array(false, $modelId1, $modelId2),
+            array(false, $modelId2, $modelId1),
+        );
+    }
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForAndModelIdIs()
+     */
+    public function testAndModelIdIs($expected, $modelId1, $modelId2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
+
+        $filter->andModelIs($modelId2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Provide test matrix for testAndModelIdIsNot.
+     *
+     * @return array
+     */
+    public function provideForAndModelIdIsNot()
+    {
+        $modelId1 = new ModelId('dummy-provider', 4);
+        $modelId2 = new ModelId('dummy-provider', 5);
+
+        return array(
+            array(false, $modelId1, $modelId1),
+            array(true, $modelId1, $modelId2),
+            array(true, $modelId2, $modelId1),
+        );
+    }
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForAndModelIdIsNot()
+     */
+    public function testAndModelIdIsNot($expected, $modelId1, $modelId2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
+
+        $filter->andModelIsNot($modelId2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Provide test matrix for testOrModelIdIs.
+     *
+     * @return array
+     */
+    public function provideForOrModelIdIs()
+    {
+        $modelId1 = new ModelId('dummy-provider', 4);
+        $modelId2 = new ModelId('dummy-provider', 5);
+        $modelId3 = new ModelId('dummy-provider', 5);
+
+        return array(
+            array(true, $modelId1, $modelId1, $modelId2),
+            array(false, $modelId1, $modelId2, $modelId3),
+            array(true, $modelId1, $modelId1, $modelId3),
+        );
+    }
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForOrModelIdIs()
+     */
+    public function testOrModelIdIs($expected, $modelId1, $modelId2, $modelId3)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
+
+        $filter->orModelIs($modelId2)->orModelIs($modelId3);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Provide test matrix for testOrModelIdIsNot.
+     *
+     * @return array
+     */
+    public function provideForOrModelIdIsNot()
+    {
+        $modelId1 = new ModelId('dummy-provider', 4);
+        $modelId2 = new ModelId('dummy-provider', 5);
+        $modelId3 = new ModelId('dummy-provider', 5);
+
+        return array(
+            array(true, $modelId1, $modelId1, $modelId2),
+            array(true, $modelId1, $modelId2, $modelId3),
+            array(false, $modelId1, $modelId1, $modelId1),
+        );
+    }
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForOrModelIdIsNot()
+     */
+    public function testOrModelIdIsNot($expected, $modelId1, $modelId2, $modelId3)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
+
+        $filter->orModelIsNot($modelId2)->orModelIsNot($modelId3);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Provide test matrix for testForModelIsFromDataProvider.
+     *
+     * @return array
+     */
+    public function provideForModelIsFromDataProvider()
+    {
+        $provider1 = 'dummy-a';
+        $provider2 = 'dummy-b';
+
+        return array(
+            array(true, $provider1, $provider1),
+            array(false, $provider1, $provider2),
+            array(true, $provider2, $provider2),
+        );
+    }
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForModelIsFromDataProvider()
+     */
+    public function testModelIsFromDataProvider($expected, $provider1, $provider2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $provider1);
+
+        $filter->andModelIsFromProvider($provider2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForModelIsFromDataProvider()
+     */
+    public function testParentIdIsFromDataProvider($expected, $provider1, $provider2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, new ModelId($provider1, 3), null);
+
+        $filter->andParentIsFromProvider($provider2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+    /**
+     * Provide test matrix for testModelIsNotFromDataProvider.
+     *
+     * @return array
+     */
+    public function provideForModelIsNotFromDataProvider()
+    {
+        $provider1 = 'dummy-a';
+        $provider2 = 'dummy-b';
+
+        return array(
+            array(false, $provider1, $provider1),
+            array(true, $provider1, $provider2),
+            array(false, $provider2, $provider2),
+        );
+    }
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForModelIsNotFromDataProvider()
+     */
+    public function testModelIsNotFromDataProvider($expected, $provider1, $provider2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $provider1);
+
+        $filter->andModelIsNotFromProvider($provider2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+
+
+    /**
+     * Test andModelIs filter.
+     *
+     * @dataProvider provideForModelIsNotFromDataProvider()
+     */
+    public function testParentIdIsNotFromDataProvider($expected, $provider1, $provider2)
+    {
+        $filter = new Filter();
+        $item   = new MockedAbstractItem(ItemInterface::CREATE, new ModelId($provider1, 3), null);
+
+        $filter->andParentIsNotFromProvider($provider2);
+
+        $this->assertEquals($expected, $filter->accepts($item));
+    }
+}

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
@@ -1,11 +1,19 @@
 <?php
+
 /**
- * PHP version 5
+ * This file is part of contao-community-alliance/dc-general.
  *
- * @package    generalDriver
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/FilterTest.php
@@ -48,6 +48,7 @@ class FilterTest extends TestCase
     public function testAndActionIs($action1, $action2)
     {
         $filter = new Filter();
+        $filter->andSub(new MockedFilter(true));
         $filter->andActionIs($action1);
 
         $item = new MockedAbstractItem($action1);
@@ -65,6 +66,7 @@ class FilterTest extends TestCase
     public function testAndActionIsNot($action1, $action2)
     {
         $filter = new Filter();
+        $filter->andSub(new MockedFilter(true));
         $filter->andActionIsNot($action1);
 
         $item = new MockedAbstractItem($action1);
@@ -82,6 +84,7 @@ class FilterTest extends TestCase
     public function testOrActionIs($action1, $action2, $action3)
     {
         $filter = new Filter();
+        $filter->orSub(new MockedFilter(false));
         $filter->orActionIs($action1)->orActionIs($action2);
 
         $item = new MockedAbstractItem($action1);
@@ -102,6 +105,7 @@ class FilterTest extends TestCase
     public function testOrActionIsNot($action1, $action2, $action3)
     {
         $filter = new Filter();
+        $filter->andSub(new MockedFilter(false));
         $filter->orActionIsNot($action1);
 
         $item = new MockedAbstractItem($action1);
@@ -122,6 +126,7 @@ class FilterTest extends TestCase
     public function testAndActionIsIn($action1, $action2, $action3)
     {
         $filter = new Filter();
+        $filter->andSub(new MockedFilter(true));
         $filter->andActionIsIn(array($action1));
 
         $item = new MockedAbstractItem($action1);
@@ -142,6 +147,7 @@ class FilterTest extends TestCase
     public function testAndActionIsNotIn($action1, $action2, $action3)
     {
         $filter = new Filter();
+        $filter->andSub(new MockedFilter(true));
         $filter->andActionIsNotIn(array($action1, $action2));
 
         $item = new MockedAbstractItem($action1);
@@ -162,7 +168,8 @@ class FilterTest extends TestCase
     public function testOrActionIsIn($action1, $action2, $action3)
     {
         $filter = new Filter();
-        $filter->andActionIsIn(array($action1));
+        $filter->orSub(new MockedFilter(false));
+        $filter->orActionIsIn(array($action1));
 
         $item = new MockedAbstractItem($action1);
         $this->assertEquals(true, $filter->accepts($item));
@@ -183,6 +190,7 @@ class FilterTest extends TestCase
     {
         $filter = new Filter();
         $filter
+            ->andSub(new MockedFilter(false))
             ->orActionIsNotIn(array($action1))
             ->orActionIsNotIn(array($action1, $action2));
 
@@ -207,6 +215,7 @@ class FilterTest extends TestCase
         $item     = new MockedAbstractItem(ItemInterface::CREATE, $parentId);
         $item2    = new MockedAbstractItem(ItemInterface::CREATE);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andHasNoParent();
 
         $this->assertEquals(false, $filter->accepts($item));
@@ -224,6 +233,7 @@ class FilterTest extends TestCase
         $item     = new MockedAbstractItem(ItemInterface::CREATE, $parentId);
         $item2    = new MockedAbstractItem(ItemInterface::CREATE);
 
+        $filter->andSub(new MockedFilter(false));
         $filter->orHasNoParent();
 
         $this->assertEquals(false, $filter->accepts($item));
@@ -258,6 +268,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
 
+        $filter->andSub(new MockedFilter(false));
         $filter->orParentIs($parentId2)->orParentIs($parentId3);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -273,6 +284,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andParentIs($parentId2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -305,6 +317,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andModelIs($modelId2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -337,6 +350,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andModelIsNot($modelId2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -370,6 +384,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
 
+        $filter->andSub(new MockedFilter(false));
         $filter->orModelIs($modelId2)->orModelIs($modelId3);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -403,6 +418,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $modelId1);
 
+        $filter->andSub(new MockedFilter(false));
         $filter->orModelIsNot($modelId2)->orModelIsNot($modelId3);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -435,6 +451,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $provider1);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andModelIsFromProvider($provider2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -450,6 +467,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, new ModelId($provider1, 3), null);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andParentIsFromProvider($provider2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -482,6 +500,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, null, $provider1);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andModelIsNotFromProvider($provider2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -498,6 +517,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, new ModelId($provider1, 3), null);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andParentIsNotFromProvider($provider2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -513,6 +533,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, new ModelId($provider1, 3), null);
 
+        $filter->andSub(new MockedFilter(false));
         $filter->orParentIsNotFromProvider($provider2);
 
         $this->assertEquals($expected, $filter->accepts($item));
@@ -528,6 +549,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andParentIsIn([$parentId2, $parentId3]);
         $this->assertEquals($expected, $filter->accepts($item));
     }
@@ -542,6 +564,7 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
 
+        $filter->andSub(new MockedFilter(true));
         $filter->andParentIsNotIn([$parentId2, $parentId3]);
         $this->assertEquals(!$expected, $filter->accepts($item));
     }
@@ -556,7 +579,8 @@ class FilterTest extends TestCase
         $filter = new Filter();
         $item   = new MockedAbstractItem(ItemInterface::CREATE, $parentId1);
 
-        $filter->andParentIsIn([$parentId2, $parentId3]);
+        $filter->andSub(new MockedFilter(false));
+        $filter->orParentIsIn([$parentId2, $parentId3]);
         $this->assertEquals($expected, $filter->accepts($item));
     }
 

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ItemTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ItemTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
+
+use ContaoCommunityAlliance\DcGeneral\Clipboard\Item;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\ItemInterface;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\UnsavedItem;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
+
+/**
+ * Class Test the items.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Test\ClipBoard
+ */
+class ItemTest extends TestCase
+{
+    const TEST_PROVIDER = 'dummy-provider';
+
+    /**
+     * Test the the Item requires an valid model id.
+     *
+     * @return void
+     */
+    public function testItemRequiresModelId()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+
+        new Item(ItemInterface::CREATE, null, null);
+    }
+
+    /**
+     * Run the tests with a parent id.
+     *
+     * @param ModelIdInterface|null $parentId Optional parent id.
+     */
+    private function runAssertsWithParentId($parentId)
+    {
+        $item        = new MockedAbstractItem(ItemInterface::CREATE, $parentId, self::TEST_PROVIDER);
+        $unsavedItem = new UnsavedItem(ItemInterface::CREATE, $parentId, self::TEST_PROVIDER);
+        $modelId     = new ModelId(self::TEST_PROVIDER, 3);
+        $item2       = new Item(ItemInterface::CREATE, $parentId, $modelId);
+
+        // Compare unsaved item and normal one.
+        $this->assertEquals(false, $item2->equals($unsavedItem));
+
+        // Test item with provider name only
+        $this->assertEquals(true, $item->equals($unsavedItem));
+        $this->assertEquals(false, $item->equals($item2));
+
+        // Test item with model id.
+        $item = new MockedAbstractItem(ItemInterface::CREATE, $parentId, $modelId);
+
+        $this->assertEquals(false, $item->equals($unsavedItem));
+        $this->assertEquals(true, $item->equals($item2));
+
+        // Test different actions.
+        $item = new MockedAbstractItem(ItemInterface::CUT, $parentId, $modelId);
+        $this->assertEquals(false, $item->equals($unsavedItem));
+        $this->assertEquals(false, $item->equals($item2));
+    }
+
+
+    /**
+     * Test the comparing.
+     *
+     * @return void
+     */
+    public function testCompare()
+    {
+        // Test without a parent id.
+        $this->runAssertsWithParentId(null);
+
+        // Test item with parent id.
+        $parentId = new ModelId('dummy-parent', 3);
+        $this->runAssertsWithParentId($parentId);
+    }
+}

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ItemTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/ItemTest.php
@@ -1,11 +1,19 @@
 <?php
+
 /**
- * PHP version 5
+ * This file is part of contao-community-alliance/dc-general.
  *
- * @package    generalDriver
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedAbstractItem.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedAbstractItem.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
+
+use ContaoCommunityAlliance\DcGeneral\Clipboard\AbstractItem;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+
+/**
+ * Mocked abstract item to test its methods.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Test\ClipBoard
+ */
+class MockedAbstractItem extends AbstractItem
+{
+    /**
+     * The model id.
+     *
+     * @var ModelIdInterface
+     */
+    private $modelId;
+
+    /**
+     * The provider name.
+     *
+     * @var string
+     */
+    private $providerName;
+
+    /**
+     * MockedAbstractItem constructor.
+     *
+     * @param string                       $action                The clipboard action name.
+     * @param ModelIdInterface|null        $parentId              The parent id.
+     * @param ModelIdInterface|string|null $modelIdOrProviderName The model id or provider name.
+     */
+    public function __construct($action, ModelIdInterface $parentId = null, $modelIdOrProviderName = null)
+    {
+        parent::__construct($action, $parentId);
+
+        if ($modelIdOrProviderName instanceof ModelIdInterface) {
+            $this->modelId      = $modelIdOrProviderName;
+        } else {
+            $this->providerName = $modelIdOrProviderName;
+        }
+    }
+
+    /**
+     * Retrieve the id of the model from this item.
+     *
+     * @return ModelId|null
+     */
+    public function getModelId()
+    {
+        return $this->modelId;
+    }
+
+    /**
+     * Retrieve the provider name of the model from this item.
+     *
+     * @return string
+     */
+    public function getDataProviderName()
+    {
+        if ($this->modelId) {
+            return $this->modelId->getDataProviderName();
+        }
+
+        return $this->providerName;
+    }
+
+    /**
+     * Get the id which identifies the item in the clipboard.
+     *
+     * @return string
+     */
+    public function getClipboardId()
+    {
+        if ($this->modelId) {
+            return $this->getAction() .
+            $this->modelId->getSerialized() .
+            (($parentId = $this->getParentId()) ? $parentId->getSerialized() : 'null');
+        } else {
+            return $this->getAction() .
+            $this->getDataProviderName() .
+            (($parentId = $this->getParentId()) ? $parentId->getSerialized() : 'null');
+        }
+    }
+}

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedAbstractItem.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedAbstractItem.php
@@ -1,11 +1,19 @@
 <?php
+
 /**
- * PHP version 5
+ * This file is part of contao-community-alliance/dc-general.
  *
- * @package    generalDriver
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
  * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedFilter.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedFilter.php
@@ -1,12 +1,20 @@
 <?php
 
 /**
- * @package    westwerk
- * @author     David Molineus <david.molineus@netzmacht.de>
- * @copyright  2015 netzmacht creative David Molineus
- * @license    LGPL 3.0
- * @filesource
+ * This file is part of contao-community-alliance/dc-general.
  *
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
+ * @filesource
  */
 
 namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedFilter.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @package    westwerk
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2015 netzmacht creative David Molineus
+ * @license    LGPL 3.0
+ * @filesource
+ *
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
+
+use ContaoCommunityAlliance\DcGeneral\Clipboard\FilterInterface;
+use ContaoCommunityAlliance\DcGeneral\Clipboard\ItemInterface;
+
+/**
+ * Mocked Filter class returns just a predefined value.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Test\ClipBoard
+ */
+class MockedFilter implements FilterInterface
+{
+    /**
+     * Accepts state.
+     *
+     * @var bool
+     */
+    private $accepts;
+
+    /**
+     * MockedFilter constructor.
+     *
+     * @param bool $accepts Accept state.
+     */
+    public function __construct($accepts)
+    {
+        $this->accepts = (bool) $accepts;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function accepts(ItemInterface $item)
+    {
+        return $this->accepts;
+    }
+}

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedSessionStorage.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedSessionStorage.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    generalDriver
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @copyright  The MetaModels team.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\ClipBoard;
+
+use ContaoCommunityAlliance\DcGeneral\SessionStorageInterface;
+
+/**
+ * This class simply mocks a session storage.
+ */
+class MockedSessionStorage implements SessionStorageInterface
+{
+    /**
+     * The values.
+     *
+     * @var array
+     */
+    private $values;
+
+    /**
+     * Checks if an attribute is defined.
+     *
+     * @param string $name The attribute name.
+     *
+     * @return bool
+     */
+    public function has($name)
+    {
+        return isset($this->values[$name]);
+    }
+
+    /**
+     * Returns an attribute.
+     *
+     * @param string $name The attribute name.
+     *
+     * @return mixed
+     */
+    public function get($name)
+    {
+        return $this->values[$name];
+    }
+
+    /**
+     * Sets an attribute.
+     *
+     * @param string $name  The attribute name.
+     *
+     * @param mixed  $value The attribute value.
+     *
+     * @return MockedSessionStorage
+     */
+    public function set($name, $value)
+    {
+        $this->values[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Returns all attributes.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->values;
+    }
+
+    /**
+     * Sets attributes.
+     *
+     * @param array $attributes Array of attributes.
+     *
+     * @return MockedSessionStorage
+     */
+    public function replace(array $attributes)
+    {
+        foreach ($attributes as $name => $value) {
+            $this->values[$name] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Removes an attribute.
+     *
+     * @param string $name The attribute name.
+     *
+     * @return MockedSessionStorage
+     */
+    public function remove($name)
+    {
+        unset($this->values[$name]);
+
+        return $this;
+    }
+
+    /**
+     * Clears all attributes.
+     *
+     * @return MockedSessionStorage
+     */
+    public function clear()
+    {
+        $this->values = array();
+
+        return $this;
+    }
+}

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedSessionStorage.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/ClipBoard/MockedSessionStorage.php
@@ -1,11 +1,20 @@
 <?php
+
 /**
- * PHP version 5
+ * This file is part of contao-community-alliance/dc-general.
  *
- * @package    generalDriver
+ * (c) 2013-2015 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  The MetaModels team.
- * @license    LGPL.
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2013-2015 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
 


### PR DESCRIPTION
This pull request rewrites some parts of the clipboard handling so that only valid `ModelIds` are used.

As discussed the `ItemInterface` got extended. Additional I had to add an `getDataProviderName` method as well for items without an model id.

It's not ready tested yet, just to inform that the work is basically done. Have a further look this weekend.