### PR TITLE
Properly use header names in list view mode

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FormatModelLabelSubscriber.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FormatModelLabelSubscriber.php
@@ -86,7 +86,7 @@ class FormatModelLabelSubscriber
 
         // Add columns.
         if ($listing->getShowColumns()) {
-            $fields = $formatter->getPropertyNames();
+            $fields = $listing->getHeaderPropertyNames();
             $args   = $modelToLabelEvent->getArgs();
 
             if (!is_array($args)) {

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
@@ -120,7 +120,6 @@ class ListView extends BaseView
         $sortingDefinition = $sorting['sorting'];
         $sortingColumns    = array();
         $pasteTopButton    = $this->renderPasteTopButton($sorting);
-        $formatter         = $listingDefinition->getLabelFormatter($definition->getName());
 
         if ($sortingDefinition) {
             /** @var GroupAndSortingDefinitionInterface $sortingDefinition */
@@ -134,7 +133,7 @@ class ListView extends BaseView
 
         // Generate the table header if the "show columns" option is active.
         if ($listingDefinition->getShowColumns()) {
-            foreach ($formatter->getPropertyNames() as $f) {
+            foreach ($listingDefinition->getHeaderPropertyNames() as $f) {
                 $property = $properties->getProperty($f);
                 if ($property) {
                     $label = $property->getLabel();


### PR DESCRIPTION
Use the header names for the list view. Listing formatter does not really make sense here.