### PR TITLE
Properly initialize the sorting.

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Event/Subscriber.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Event/Subscriber.php
@@ -24,6 +24,7 @@ use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\Decod
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetPanelElementTemplateEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetPropertyOptionsEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\ResolveWidgetErrorMessageEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ViewHelpers;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
 use ContaoCommunityAlliance\DcGeneral\DcGeneralEvents;
@@ -342,10 +343,13 @@ class Subscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var Contao2BackendViewDefinitionInterface $viewDefinition */
+        /** @var Contao2BackendViewDefinitionInterface $backendDefinition */
+        $backendDefinition = $definition->getDefinition(Contao2BackendViewDefinitionInterface::NAME);
+        $listingConfig     = $backendDefinition->getListingConfig();
+
         $dataConfig = $environment->getBaseConfigRegistry()->getBaseConfig();
         $panel      = $view->getPanel();
 
-        $panel->initialize($dataConfig);
+        ViewHelpers::initializeSorting($panel, $dataConfig, $listingConfig);
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ListView.php
@@ -49,6 +49,11 @@ class ListView extends BaseView
         $dataProvider = $environment->getDataProvider();
         $dataConfig   = $environment->getBaseConfigRegistry()->getBaseConfig();
 
+        $listingConfig = $this->getViewSection()->getListingConfig();
+        $panel         = $this->getPanel();
+
+        ViewHelpers::initializeSorting($panel, $dataConfig, $listingConfig);
+
         return $dataProvider->fetchAll($dataConfig);
     }
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ParentView.php
@@ -58,6 +58,11 @@ class ParentView extends BaseView
         $dataProvider = $environment->getDataProvider();
         $childConfig  = $environment->getBaseConfigRegistry()->getBaseConfig();
 
+        $listingConfig = $this->getViewSection()->getListingConfig();
+        $panel         = $this->getPanel();
+
+        ViewHelpers::initializeSorting($panel, $childConfig, $listingConfig);
+
         return $dataProvider->fetchAll($childConfig);
     }
 


### PR DESCRIPTION
This pull request fixes the sorting issues described in #154. Somehow this fix wasn't published to github but I fixed it some times ago...

The reintroducing of the sorting in the list and parent view is required as the `BaseConfigRegistry` does not react as I would expect from a registry. Instead of storing one instance it returns a new clone of a base registry.

My initial idea was that the sorting would get initialized in https://github.com/contao-community-alliance/dc-general/compare/contao-community-alliance:develop...dmolineus:fix/sorting-issues?expand=1#diff-c33729d7abe4e062a7b8b47101611198R353 globally so the next time getting the base config would contain the initialized sorting.

I was thinking about to provide a way to manipulate the template base config being stored in the registry so that every config would contain the default sorting settings. Not sure about side effects, so I just duplicate the sorting initializing.