### PR TITLE
Prevent that the sorting manager creates exceeding deltas.

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/SortingManager.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/SortingManager.php
@@ -4,6 +4,7 @@
  *
  * @package    DcGeneral
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  The Contao Community Alliance.
  * @license    LGPL.
  * @filesource
@@ -274,7 +275,9 @@ class SortingManager
     }
 
     /**
-     * Determine delta value: ((next sorting - current sorting) / amount of insert models).
+     * Determine delta value.
+     *
+     * Delta value will be between 2 and a multiple 128 which is large enough to contain all models being moved.
      *
      * @return float|int
      */
@@ -283,11 +286,13 @@ class SortingManager
         $delta = (
             ($this->marker->getProperty($this->getSortingProperty()) - $this->position) / $this->results->length()
         );
+
         // If delta too narrow, we need to make room.
-        if ($delta < 2) {
-            $delta = 128;
-            return $delta;
+        // Prevent delta to exceed, also. Use minimum delta which is calculated as multiple of 128.
+        if ($delta < 2 || $delta > 128) {
+            return (ceil($this->results->length() / 128) * 128);
         }
+
         return $delta;
     }
 

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/Controller/SortingManagerTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/Controller/SortingManagerTest.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * PHP version 5
+ *
+ * @package    DcGeneral
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  The Contao Community Alliance.
+ * @license    LGPL.
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\Controller;
+
+use ContaoCommunityAlliance\DcGeneral\Controller\SortingManager;
+use ContaoCommunityAlliance\DcGeneral\Data\CollectionInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\DefaultCollection;
+use ContaoCommunityAlliance\DcGeneral\Data\DefaultModel;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
+
+/**
+ * Test case for the sorting manager.
+ *
+ * @package ContaoCommunityAlliance\DcGeneral\Test\Controller
+ */
+class SortingManagerTest extends TestCase
+{
+    /**
+     * Data provider for test the sorting.
+     *
+     * It creates a matrix with following entries for each row:
+     *  - model data [id => sorting, id2 => sorting2, ...]
+     *  - list of models being moved [id, id2, ...]
+     *  - optional previous id or null
+     *  - expected order of the ids.
+     *
+     * @return array
+     */
+    public function provideTestData()
+    {
+        return array(
+            // Test with default gap, without previous model
+            array(
+                array(
+                    1 => 128,
+                    2 => 256,
+                    3 => 384
+                ),
+                array(3),
+                null,
+                array(3, 1, 2)
+            ),
+            // Test with minimum gap, without previous model
+            array(
+                array(
+                    1 => 2,
+                    2 => 4,
+                    3 => 6
+                ),
+                array(3),
+                null,
+                array(3, 1, 2)
+            ),
+            // Test with large gap, without previous model
+            array(
+                array(
+                    1 => 2,
+                    2 => 1280,
+                    3 => 5560
+                ),
+                array(3),
+                null,
+                array(3, 1, 2)
+            ),
+            // Test with default gap and with previous model
+            array(
+                array(
+                    1 => 128,
+                    2 => 256,
+                    3 => 384
+                ),
+                array(3),
+                1,
+                array(1,3,2)
+            ),
+            // Test with minimum gap and previous model
+            array(
+                array(
+                    1 => 2,
+                    2 => 4,
+                    3 => 6
+                ),
+                array(3),
+                1,
+                array(1,3,2)
+            ),
+            // Test with large gap, and previous model
+            array(
+                array(
+                    1 => 2,
+                    2 => 1280,
+                    3 => 5560
+                ),
+                array(3),
+                1,
+                array(1, 3, 2)
+            ),
+            // Test with multiple items being moved, no previous model
+            array(
+                array(
+                    1 => 2,
+                    2 => 1280,
+                    3 => 5560
+                ),
+                array(3, 2),
+                null,
+                array(2, 3, 1)
+            ),
+            // Test with multiple items being moved, with previous model
+            array(
+                array(
+                    1 => 2,
+                    4 => 128,
+                    2 => 1280,
+                    3 => 5560,
+                ),
+                array(3, 2),
+                4,
+                array(1, 4, 2, 3)
+            ),
+        );
+    }
+
+    /**
+     * Prepare the required collections from provided test data.
+     *
+     * @param array|ModelIdInterface[] $siblings          List of all models.
+     * @param array                    $resortingIds      Resorting ids.
+     * @param int|null                 $previousModelId   Previous model ids.
+     * @param CollectionInterface      $siblingCollection The sibling collection.
+     * @param CollectionInterface      $modelCollection   The model collection of models being moved.
+     * @param ModelIdInterface|null    $previousModel     Optional previous model.
+     *
+     * @return void.
+     */
+    protected function prepareCollections(
+        array &$siblings,
+        array $resortingIds,
+        $previousModelId,
+        $siblingCollection,
+        $modelCollection,
+        &$previousModel
+    ) {
+        foreach ($siblings as $id => $sorting) {
+            $model = new DefaultModel();
+            $model->setID($id);
+            $model->setProperty('sorting', $sorting);
+
+            $siblingCollection->push($model);
+            $siblings[$id] = $model;
+
+            if (in_array($id, $resortingIds)) {
+                $modelCollection->push($model);
+            }
+
+            if ($id === $previousModelId) {
+                $previousModel = $model;
+            }
+        }
+    }
+
+    /**
+     * Test if the sorting is applied as expected.
+     *
+     * We do not test the specific sorting value, only make sure that
+     *  + is greater than the previous one
+     *  + that the actual and the previous one be between 2 and 128
+     *
+     * @param array    $siblings        Create model for the sibling.
+     * @param array    $resortingIds    Ids of items being resorted.
+     * @param int|null $previousModelId Previous model id.
+     * @param array    $expectedOrder   Expected order.
+     *
+     * @dataProvider provideTestData()
+     */
+    public function testAppliedSorting(array $siblings, array $resortingIds, $previousModelId, array $expectedOrder)
+    {
+        $siblingCollection = new DefaultCollection();
+        $modelCollection   = new DefaultCollection();
+        $previousModel     = null;
+
+        $this->prepareCollections(
+            $siblings,
+            $resortingIds,
+            $previousModelId,
+            $siblingCollection,
+            $modelCollection,
+            $previousModel
+        );
+
+        $sortingManager = new SortingManager($modelCollection, $siblingCollection, 'sorting', $previousModel);
+        $position       = $previousModel ? $previousModel->getProperty('sorting') : null;
+        $affected       = $sortingManager->getResults()->getModelIds();
+        $ordered        = array();
+
+        foreach ($expectedOrder as $id) {
+            // Only compare if previous model is given and not identical with test model.
+            // Only test affected items as well.
+            if ($previousModel && $previousModel->getId() != $id && in_array($id, $affected)) {
+                $this->assertGreaterThan($position, $siblings[$id]->getProperty('sorting'));
+                $this->assertGreaterThanOrEqual(2, ($siblings[$id]->getProperty('sorting') - $position));
+                $this->assertLessThanOrEqual(128, ($siblings[$id]->getProperty('sorting') - $position));
+            }
+
+            $previousModel = $siblings[$id];
+            $position      = $previousModel->getProperty('sorting');
+
+            $ordered[$position] = $id;
+        }
+
+        // Explicit compare the new order with expected order.
+        ksort($ordered);
+        $this->assertEquals(array_values($ordered), $expectedOrder);
+    }
+}


### PR DESCRIPTION
This pull request provides a fix for #149. The sorting manager could create deltas which would exceed soon as it calculates the delta as difference between the current position and the next element.

If the difference is too big (f.e. the models here got deleted or moved at the end), the issue occurs.

This PR also fixes the (theoretical) issue that the default delta (128) being returned could be lesser than the number of items being moved.