### PR TITLE
Fix missing default sorting and grouping information

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
@@ -790,6 +790,11 @@ class LegacyDcaDataDefinitionBuilder extends DcaReadingDataDefinitionBuilder
             $information->setManualSorting();
         }
 
+        // If no default sorting and grouping definition is defined, assume the first one is default.
+        if (!$definitions->hasDefault()) {
+            $definitions->markDefault($definition);
+        }
+
         $flag = empty($propInfo['flag']) ? $this->getFromDca('list/sorting/flag') : $propInfo['flag'];
         $this->evalFlag($information, $flag);
     }


### PR DESCRIPTION
This pull request fixes the missing default sorting and grouping information. If no default sorting and grouping information is defined, it assumes the first sorting definition is the default one.

It fixes issue mentioned in https://github.com/MetaModels/core/issues/864#issuecomment-156238053.