### PR TITLE
Hotfix zu https://github.com/MetaModels/core/issues/945 - Angabe 'ID'…

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/EditMask.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/EditMask.php
@@ -540,15 +540,15 @@ class EditMask
         $translator     = $this->getEnvironment()->getTranslator();
 
         if ($this->model->getId()) {
-            $headline = $translator->translate('editRecord', $definitionName, array('ID ' . $this->model->getId()));
+            $headline = $translator->translate('editRecord', $definitionName, array($this->model->getId()));
 
             if ($headline !== 'editRecord') {
                 return $headline;
             }
-            return $translator->translate('MSC.editRecord', null, array('ID ' . $this->model->getId()));
+            return $translator->translate('MSC.editRecord', null, array($this->model->getId()));
         }
 
-        $headline = $translator->translate('newRecord', $definitionName, array('ID ' . $this->model->getId()));
+        $headline = $translator->translate('newRecord', $definitionName, array($this->model->getId()));
         if ($headline !== 'newRecord') {
             return $headline;
         }


### PR DESCRIPTION
… ist im Übersetzungsstring schon enthalten.