### PR TITLE
Changed \String::* calls to \StringUtil for PHP7 compatibility reasons

### DIFF
--- a/contao/templates/widget_filetree.html5
+++ b/contao/templates/widget_filetree.html5
@@ -5,7 +5,7 @@
     <?php endif; ?>
     <ul id="sort_<?php echo $this->id; ?>" class="<?php echo trim(($this->hasOrder ? 'sortable ' : '') . ($this->isGallery ? 'sgallery' : '')); ?>">
     <?php foreach ($this->icons as $id => $icon): ?>
-        <?php if (version_compare('3.5.5', VERSION, '>=')): ?>
+        <?php if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')): ?>
             <li data-id="<?php echo \StringUtil::binToUuid($id); ?>"><?php echo $icon; ?></li>
         <?php else: ?>
             <li data-id="<?php echo \String::binToUuid($id); ?>"><?php echo $icon; ?></li>

--- a/contao/templates/widget_filetree.html5
+++ b/contao/templates/widget_filetree.html5
@@ -5,7 +5,11 @@
     <?php endif; ?>
     <ul id="sort_<?php echo $this->id; ?>" class="<?php echo trim(($this->hasOrder ? 'sortable ' : '') . ($this->isGallery ? 'sgallery' : '')); ?>">
     <?php foreach ($this->icons as $id => $icon): ?>
-        <li data-id="<?php echo \String::binToUuid($id); ?>"><?php echo $icon; ?></li>
+        <?php if (version_compare('3.5.5', VERSION, '>=')): ?>
+            <li data-id="<?php echo \StringUtil::binToUuid($id); ?>"><?php echo $icon; ?></li>
+        <?php else: ?>
+            <li data-id="<?php echo \String::binToUuid($id); ?>"><?php echo $icon; ?></li>
+        <?php endif; ?>
     <?php endforeach; ?>
     </ul>
 </div>

--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/Ajax3X.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/Ajax3X.php
@@ -182,7 +182,7 @@ class Ajax3X extends Ajax
             if ($strType == 'file') {
                 // PHP 7 compatibility
                 // See #309 (https://github.com/contao/core-bundle/issues/309)
-                if (version_compare('3.5.5', VERSION, '>=')) {
+                if (version_compare('3.5.5', VERSION . '.' . BUILD, '>=')) {
                     foreach ($varValue as $k => $v) {
                         $varValue[$k] = \StringUtil::binToUuid(\Dbafs::addResource($v)->uuid);
                     }

--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/Ajax3X.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/Ajax3X.php
@@ -180,8 +180,16 @@ class Ajax3X extends Ajax
 
             // Automatically add resources to the DBAFS.
             if ($strType == 'file') {
-                foreach ($varValue as $k => $v) {
-                    $varValue[$k] = \String::binToUuid(\Dbafs::addResource($v)->uuid);
+                // PHP 7 compatibility
+                // See #309 (https://github.com/contao/core-bundle/issues/309)
+                if (version_compare('3.5.5', VERSION, '>=')) {
+                    foreach ($varValue as $k => $v) {
+                        $varValue[$k] = \StringUtil::binToUuid(\Dbafs::addResource($v)->uuid);
+                    }
+                } else {
+                    foreach ($varValue as $k => $v) {
+                        $varValue[$k] = \String::binToUuid(\Dbafs::addResource($v)->uuid);
+                    }
                 }
             }
         }


### PR DESCRIPTION
PHP 7 compatibility - see contao/core-bundle#309.