### PR TITLE
Hotfix für 188

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/EditMask.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/EditMask.php
@@ -774,7 +774,7 @@ class EditMask
     {
         $environment  = $this->getEnvironment();
         $definition   = $environment->getDataDefinition();
-        $legendStates = $environment->getSessionStorage()->get('LEGENDS');
+        $legendStates = (array) $environment->getSessionStorage()->get('LEGENDS');
 
         if (array_key_exists($definition->getName(), $legendStates)) {
             $legendStates = $legendStates[$definition->getName()];

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/ModelId.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/ModelId.php
@@ -58,7 +58,7 @@ class ModelId implements ModelIdInterface
             throw new DcGeneralInvalidArgumentException('Can\'t instantiate model id. No data provider name given.');
         }
 
-        if (empty($modelId)) {
+        if (!strlen($modelId)) {
             throw new DcGeneralInvalidArgumentException('Can\'t instantiate model id. No model id given.');
         }
 


### PR DESCRIPTION
This pull request addresses the issue described in #188. It loosens the ModelId constructor value validation. Using strlen the case of a stringified uuid should also be recognized.