### PR TITLE
FallbackResetSubscriber fix getSubscribedEvents

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FallbackResetSubscriber.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FallbackResetSubscriber.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2015 Contao Community Alliance.
+ * (c) 2013-2016 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
  * @copyright  2013-2016 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -51,7 +52,7 @@ class FallbackResetSubscriber implements EventSubscriberInterface
     {
         return array(
             PostPersistModelEvent::NAME => array('handlePostPersistModelEvent', -200),
-            PostDuplicateModelEvent::NAME => array('handlePostPersistModelEvent', -200)
+            PostDuplicateModelEvent::NAME => array('handlePostDuplicateModelEvent', -200)
         );
     }
 


### PR DESCRIPTION
PostDuplicateModelEvent::NAME is linked in wrong method .

This fix is tested.