### PR TITLE
Prevent error "Cannot use isset() on the result of a function call"

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
@@ -378,7 +378,7 @@ class DefaultController implements ControllerInterface
                 $model->setProperty($property, $value);
                 // If always save is true, we need to mark the model as changed.
                 if ($properties->hasProperty($property)
-                    && isset($properties->getProperty($property)->getExtra()['alwaysSave'])
+                    && null !== ($properties->getProperty($property)->getExtra()['alwaysSave'])
                 ) {
                     $model->setMeta($model::IS_CHANGED, true);
                 }


### PR DESCRIPTION
In PHP 5.6 calling isset() on a function call throws a fatal error.