### PR TITLE
Hotfix/reset fallback

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Data/DataProviderInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/DataProviderInterface.php
@@ -212,6 +212,8 @@ interface DataProviderInterface
      * @param string $strField The field to reset.
      *
      * @return void
+     *
+     * @deprecated Handle the resetting manually as you must filter the models.
      */
     public function resetFallback($strField);
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultDataProvider.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultDataProvider.php
@@ -551,7 +551,7 @@ class DefaultDataProvider implements DataProviderInterface
         /** @var \Contao\Database\Result $dbResult */
         foreach ($dbResult->row() as $key => $value) {
             if ($key == $this->idProperty) {
-                $objModel->setId($value);
+                $objModel->setIdRaw($value);
             }
 
             $objModel->setPropertyRaw($key, deserialize($value));

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultDataProvider.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultDataProvider.php
@@ -722,6 +722,10 @@ class DefaultDataProvider implements DataProviderInterface
      */
     public function resetFallback($strField)
     {
+        // @codingStandardsIgnoreStart
+        @trigger_error(__CLASS__ . '::' . __METHOD__ . ' is deprecated - handle resetting manually', E_USER_DEPRECATED);
+        // @codingStandardsIgnoreEnd
+
         $this->objDatabase->query('UPDATE ' . $this->strSource . ' SET ' . $strField . ' = \'\'');
     }
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultModel.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultModel.php
@@ -122,9 +122,23 @@ class DefaultModel extends AbstractModel
     public function setID($mixID)
     {
         if ($this->mixID == null) {
-            $this->mixID = $mixID;
+            $this->setIdRaw($mixID);
             $this->setMeta(static::IS_CHANGED, true);
         }
+    }
+
+    /**
+     * Set the id for this object.
+     *
+     * This method is not interfaced and MUST only be used for initial values from the data provider.
+     *
+     * @param mixed $mixID Could be a integer, string or anything else - depends on the provider implementation.
+     *
+     * @return void
+     */
+    public function setIdRaw($mixID)
+    {
+        $this->mixID = $mixID;
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/NoOpDataProvider.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/NoOpDataProvider.php
@@ -185,6 +185,9 @@ class NoOpDataProvider implements DataProviderInterface
      */
     public function resetFallback($strField)
     {
+        // @codingStandardsIgnoreStart
+        @trigger_error(__CLASS__ . '::' . __METHOD__ . ' is deprecated - handle resetting manually', E_USER_DEPRECATED);
+        // @codingStandardsIgnoreEnd
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/DataDefinition/ModelRelationship/RootCondition.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/DataDefinition/ModelRelationship/RootCondition.php
@@ -19,6 +19,7 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\DataDefinition\ModelRelationship;
 
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
 use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
 
 /**
@@ -108,6 +109,8 @@ class RootCondition extends AbstractCondition implements RootConditionInterface
      */
     public function applyTo($objModel)
     {
+        $this->guardProviderName($objModel);
+
         if ($this->setOn) {
             foreach ($this->setOn as $rule) {
                 if (!($rule['property'] && isset($rule['value']))) {
@@ -137,6 +140,12 @@ class RootCondition extends AbstractCondition implements RootConditionInterface
      */
     public function matches($objModel)
     {
+        try {
+            $this->guardProviderName($objModel);
+        } catch (\InvalidArgumentException $exception) {
+            return false;
+        }
+
         if ($this->getFilterArray()) {
             return $this->checkCondition(
                 $objModel,
@@ -148,5 +157,23 @@ class RootCondition extends AbstractCondition implements RootConditionInterface
         }
 
         return true;
+    }
+
+    /**
+     * Guard that the data provider name matches.
+     *
+     * @param ModelInterface $model The model.
+     *
+     * @return void
+     *
+     * @throws \InvalidArgumentException When any provider name mismatches.
+     */
+    private function guardProviderName($model)
+    {
+        if ($model->getProviderName() !== $this->sourceProvider) {
+            throw new \InvalidArgumentException(
+                sprintf('provider name %s is not equal to %s', $model->getProviderName(), $this->getSourceName())
+            );
+        }
     }
 }

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/DataDefinition/ModelRelationship/ParentChildConditionTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/DataDefinition/ModelRelationship/ParentChildConditionTest.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2015 Contao Community Alliance.
+ * (c) 2013-2016 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,7 +12,7 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2013-2015 Contao Community Alliance.
+ * @copyright  2013-2016 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -23,8 +23,76 @@ use ContaoCommunityAlliance\DcGeneral\Data\DefaultModel;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\ModelRelationship\ParentChildCondition;
 use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
 
+/**
+ * This class tests the ParentChildCondition.
+ */
 class ParentChildConditionTest extends TestCase
 {
+    /**
+     * Test that the matches method does not match for children from another provider.
+     *
+     * @return void
+     */
+    public function testMatchesForChildFromOtherProvider()
+    {
+        $parent = new DefaultModel();
+        $parent->setId(1);
+        $parent->setProviderName('test-provider');
+
+        $child = new DefaultModel();
+        $child->setPropertyRaw('pid', 1);
+        $child->setProviderName('test2-provider');
+
+        $condition = new ParentChildCondition();
+        $condition
+            ->setFilterArray(
+                [[
+                     'local'     => 'id',
+                     'operation' => '=',
+                     'remote'    => 'pid'
+                ]]
+            )
+            ->setSourceName('test-provider')
+            ->setDestinationName('test-provider');
+
+        $this->assertFalse($condition->matches($parent, $child));
+    }
+
+    /**
+     * Test that the matches method does not match for children from another provider.
+     *
+     * @return void
+     */
+    public function testMatchesForParentFromOtherProvider()
+    {
+        $parent = new DefaultModel();
+        $parent->setId(1);
+        $parent->setProviderName('test2-provider');
+
+        $child = new DefaultModel();
+        $child->setPropertyRaw('pid', 1);
+        $child->setProviderName('test-provider');
+
+        $condition = new ParentChildCondition();
+        $condition
+            ->setFilterArray(
+                [[
+                     'local'     => 'id',
+                     'operation' => '=',
+                     'remote'    => 'pid'
+                ]]
+            )
+            ->setSourceName('test-provider')
+            ->setDestinationName('test-provider');
+
+        $this->assertFalse($condition->matches($parent, $child));
+    }
+
+    /**
+     * Test the matches method().
+     *
+     * @return void
+     */
     public function testMatches()
     {
         $parent = new DefaultModel();
@@ -43,6 +111,11 @@ class ParentChildConditionTest extends TestCase
         $this->assertTrue($condition->matches($parent, $child));
     }
 
+    /**
+     * Test the matches method().
+     *
+     * @return void
+     */
     public function testMatchesRemoteValue()
     {
         $parent = new DefaultModel();

--- a/tests/ContaoCommunityAlliance/DcGeneral/Test/DataDefinition/ModelRelationship/RootConditionTest.php
+++ b/tests/ContaoCommunityAlliance/DcGeneral/Test/DataDefinition/ModelRelationship/RootConditionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2016 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @copyright  2013-2016 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\DataDefinition\ModelRelationship;
+
+use ContaoCommunityAlliance\DcGeneral\Data\DefaultModel;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\ModelRelationship\RootCondition;
+use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
+
+/**
+ * This class tests the RootCondition.
+ */
+class RootConditionTest extends TestCase
+{
+    /**
+     * Test that the matches method does not match for models from another provider.
+     *
+     * @return void
+     */
+    public function testMatchesForChildFromOtherProvider()
+    {
+        $model = new DefaultModel();
+        $model->setId(1);
+        $model->setProviderName('test2-provider');
+        $model->setProperty('pid', 0);
+
+        $condition = new RootCondition();
+        $condition
+            ->setFilterArray(
+                [[
+                     'value'     => '0',
+                     'operation' => '=',
+                     'property'  => 'pid'
+                ]]
+            )
+            ->setSourceName('test-provider');
+
+        $this->assertFalse($condition->matches($model));
+    }
+
+    /**
+     * Test the matches method().
+     *
+     * @return void
+     */
+    public function testMatches()
+    {
+        $model = new DefaultModel();
+        $model->setId(1);
+        $model->setProviderName('test-provider');
+        $model->setProperty('pid', 0);
+
+        $condition = new RootCondition();
+        $condition
+            ->setFilterArray(
+                [[
+                     'value'     => '0',
+                     'operation' => '=',
+                     'property'  => 'pid'
+                 ]]
+            )
+            ->setSourceName('test-provider');
+
+        $this->assertTrue($condition->matches($model));
+    }
+}


### PR DESCRIPTION
This is an attempt to solve #303 (which is duped by MetaModels/core#35).

We are now examining the parent child relationship of the data container to determine the siblings of the passed model and reset only within those.

Additionally, the method `DataProviderInterface::resetFallback()` has been deprecated, as it won't be possible to implement it properly without passing a config and/or making the driver stateful of which both are not good at all.

I like the approach to shift the responsibility into the reset listener much more.

Please test this implementation, I performed tests with MetaModels/core and defining render settings and input screens worked again.