### PR TITLE
Update DefaultSearchElement.php

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Panel/DefaultSearchElement.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Panel/DefaultSearchElement.php
@@ -144,15 +144,11 @@ class DefaultSearchElement extends AbstractElement implements SearchElementInter
             array_merge_recursive(
                 $arrCurrent,
                 array(
-                    array(
-                        'operation' => 'AND',
-                        'children'  => array(
-                            array(
-                                'operation' => 'LIKE',
-                                'property'  => $this->getSelectedProperty(),
-                                'value'     => sprintf('*%s*', $this->getValue())
-                            )
-                        )
+                     array(
+                                 'operation' => '=',
+                                 'property'  => $this->getSelectedProperty(),
+                                 'value'     => sprintf('*%s*', $this->getValue())
+                             )
                     )
                 )
             )


### PR DESCRIPTION
This Fix solves the problem that the panel elements filter and search don't work with each other. The child-condition didn't work, so i write this additional condition in the same level. I regognized this Issue in the MetaModels Backend core-master and core-alpha15