### PR TITLE
Hotfix #342 set standard at sortgroup

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultDataProvider.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/DefaultDataProvider.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2016 Contao Community Alliance.
+ * (c) 2013-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -21,7 +21,8 @@
  * @author     Simon Kusterer <simon@soped.com>
  * @author     Christopher Boelter <christopher@boelter.eu>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2016 Contao Community Alliance.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2013-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -531,7 +532,7 @@ class DefaultDataProvider implements DataProviderInterface
             ->execute();
 
         if (!isset($data[$this->idProperty]) && strlen($insertResult->insertId)) {
-            $model->setId($insertResult->insertId);
+            $model->setId((string) $insertResult->insertId);
         }
     }
 


### PR DESCRIPTION
Hotfix #342 set standard at sortgroup

cast id as string because contao get all ids from database as string