### PR TITLE
[RTM] Find the parent id for the Contao breadcrumb

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/DC/General.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/DC/General.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2016 Contao Community Alliance.
+ * (c) 2013-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,7 +20,7 @@
  * @author     Simon Kusterer <simon@soped.com>
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2016 Contao Community Alliance.
+ * @copyright  2013-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -30,6 +30,7 @@ namespace ContaoCommunityAlliance\DcGeneral;
 use Contao\DataContainer;
 use ContaoCommunityAlliance\DcGeneral\Contao\Callback\Callbacks;
 use ContaoCommunityAlliance\DcGeneral\Controller\ControllerInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\Exception\DcGeneralRuntimeException;
 use ContaoCommunityAlliance\DcGeneral\Factory\DcGeneralFactory;
 use ContaoCommunityAlliance\DcGeneral\Factory\Event\PopulateEnvironmentEvent;
@@ -202,9 +203,23 @@ class DC_General extends DataContainer implements DataContainerInterface
      */
     public function __get($name)
     {
+        $environment          = $this->getEnvironment();
+        $inputProvider        = $environment->getInputProvider();
+        $dataDefinition       = $environment->getDataDefinition();
+
         switch ($name) {
+            case 'id':
+                // Step 1: Find the parent id for the Contao breadcrumb.
+                $idParameter = $inputProvider->hasParameter('id') ? 'id' : 'pid';
+
+                // Step 2: Check if the parameter really exists.
+                if (false === $inputProvider->hasParameter($idParameter)) {
+                    break;
+                }
+
+                return ModelId::fromSerialized($inputProvider->getParameter($idParameter))->getId();
             case 'table':
-                return $this->getEnvironment()->getDataDefinition()->getName();
+                return $dataDefinition->getName();
             default:
         }
 


### PR DESCRIPTION
This hotfix is for Contao breadcrumb.
If provide parent table in the data container configuration is set, then will get Contao backend with the magic getter becomes the id from the parent entry.

SEE:
Contao 3.5:
https://github.com/contao/core/blob/master/system/modules/core/classes/Backend.php#L548
Contao 4.4:
https://github.com/contao/core-bundle/blob/master/src/Resources/contao/classes/Backend.php#L510
