### PR TITLE
[RTM] Add missing selectable sub selector to the sub palette parser

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Palette/LegacyPalettesParser.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Palette/LegacyPalettesParser.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2015 Contao Community Alliance.
+ * (c) 2013-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -14,7 +14,8 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     David Maack <david.maack@arcor.de>
- * @copyright  2013-2015 Contao Community Alliance.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2013-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -295,10 +296,19 @@ class LegacyPalettesParser
 
             $selectorFieldName = $this->createSubpaletteSelectorFieldName($subPaletteSelector, $selectorFieldNames);
 
+            $selectorProperty = array();
+            // For selectable sub selector.
+            if (isset($properties[$selectorFieldName])
+                && (0 < substr_count($subPaletteSelector, '_'))
+            ) {
+                $selectorProperty = $properties[$selectorFieldName];
+            }
+
             $properties[$selectorFieldName] = $this->parseSubpalette(
                 $subPaletteSelector,
                 $childFields,
-                $selectorFieldNames
+                $selectorFieldNames,
+                $selectorProperty
             );
         }
 
@@ -312,18 +322,22 @@ class LegacyPalettesParser
      *
      * @param string $childFields        List of the properties for the sub palette.
      *
-     * @param array  $selectorFieldNames List of the selector properties [optional].
+     * @param array $selectorFieldNames List of the selector properties [optional].
+     *
+     * @param array $properties         List of the selector visible properties [optional].
      *
      * @return PropertyInterface[]
      */
-    public function parseSubpalette($subPaletteSelector, $childFields, array $selectorFieldNames = array())
-    {
+    public function parseSubpalette(
+        $subPaletteSelector,
+        $childFields,
+        array $selectorFieldNames = array(),
+        array $properties = array()
+    ) {
         $childFields = explode(',', $childFields);
         $childFields = array_map('trim', $childFields);
 
         $condition = $this->createSubpaletteCondition($subPaletteSelector, $selectorFieldNames);
-
-        $properties = array();
 
         foreach ($childFields as $childField) {
             $property = new Property($childField);


### PR DESCRIPTION
When we have a selectable sub selector, this has don´t work. This pull request is for work it.

As example what i mean here. By the Contao module news by news setting. Their is an selectable sub selector field `source`. You can switch here the sources with a radio button menu.

