### PR TITLE
[WRONG] Return from general the missing active record

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/DC/General.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/DC/General.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2016 Contao Community Alliance.
+ * (c) 2013-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -20,7 +20,7 @@
  * @author     Simon Kusterer <simon@soped.com>
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2016 Contao Community Alliance.
+ * @copyright  2013-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -205,6 +205,8 @@ class DC_General extends DataContainer implements DataContainerInterface
         switch ($name) {
             case 'table':
                 return $this->getEnvironment()->getDataDefinition()->getName();
+            case 'activeRecord':
+                return $this->activeRecord;
             default:
         }
 


### PR DESCRIPTION
If by the property the load callback defined and in the callback method would like the active record.

Show for example:
https://github.com/contao/core/blob/master/system/modules/core/dca/tl_content.php#L1619