### PR TITLE
[WIP] Fix model operation button callback listener

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ModelOperationButtonCallbackListener.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ModelOperationButtonCallbackListener.php
@@ -64,7 +64,7 @@ class ModelOperationButtonCallbackListener extends AbstractReturningCallbackList
     {
         return parent::wantToExecute($event)
         && (empty($this->operationName)
-            || ($event->getKey() == $this->operationName)
+            || ($event->getCommand()->getName() == $this->operationName)
         );
     }
 


### PR DESCRIPTION
By model operation button callback listener compare the operation with the command name instead with the key