### PR TITLE
[RTM] Feature: Implement the own file selector popup

### DIFF
--- a/contao/backend/generalfile.php
+++ b/contao/backend/generalfile.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2017 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2013-2017 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
+ * @filesource
+ */
+
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\FileSelect;
+
+define('TL_MODE', 'BE');
+
+// Search the initialize.php.
+$dir = dirname($_SERVER['SCRIPT_FILENAME']);
+
+while ($dir != '.' && $dir != '/' && !is_file($dir . '/system/initialize.php')) {
+    $dir = dirname($dir);
+}
+
+if (!is_file($dir . '/system/initialize.php')) {
+    echo 'Could not find initialize.php, where is Contao?';
+    exit;
+}
+
+define('TL_SCRIPT', 'system/modules/dc-general/backend/generalfile.php');
+
+require_once $dir . '/system/initialize.php';
+
+$objTreePicker = new FileSelect();
+$objTreePicker->run();

--- a/contao/config/config.php
+++ b/contao/config/config.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2015 Contao Community Alliance.
+ * (c) 2013-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -16,7 +16,8 @@
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     Andreas Isaak <andy.jared@googlemail.com>
  * @author     Oliver Hoff <oliver@hofff.com>
- * @copyright  2013-2015 Contao Community Alliance.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2013-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -32,5 +33,7 @@ if (TL_MODE == 'BE') {
 $GLOBALS['BE_FFL']['DcGeneralTreePicker'] =
     'ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\TreePicker';
 
-$GLOBALS['TL_HOOKS']['executePostActions'][] =
-    array('ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\TreePicker', 'updateAjax');
+$GLOBALS['TL_HOOKS']['executePostActions'] = array_merge((array) $GLOBALS['TL_HOOKS']['executePostActions'], array(
+    array('ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\TreePicker', 'updateAjax'),
+    array('ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget\FileTree', 'updateAjax')
+));

--- a/contao/templates/widget_filetree.html5
+++ b/contao/templates/widget_filetree.html5
@@ -1,24 +1,25 @@
 <input type="hidden" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" value="<?= $this->value ?>">
+
 <div class="selector_container">
     <?php if ($this->hasOrder && count($this->icons) > 1): ?>
         <p class="sort_hint"><?= $this->translate('dragItemsHint', 'MSC') ?></p>
     <?php endif; ?>
     <ul id="sort_<?= $this->id ?>" class="<?= trim(($this->hasOrder ? 'sortable ' : '') . ($this->isGallery ? 'sgallery' : '')) ?>">
-        <?php foreach ($this->icons as $id => $icon): ?>
+        <?php foreach ($this->icons as $icon): ?>
         <li data-id="<?php
         // PHP 7 compatibility, see https://github.com/contao/core-bundle/issues/309
         if (version_compare(VERSION . '.' . BUILD, '3.5.5', '>=')) {
-            echo \StringUtil::binToUuid($id);
+            echo \StringUtil::binToUuid($icon['uuid']);
         } else {
-            echo \String::binToUuid($id);
+            echo \String::binToUuid($icon['uuid']);
         }
-        ?>"><?= $icon ?></li>
+        ?>"><?= $icon['image'] ?></li>
         <?php endforeach; ?>
     </ul>
-</div>
 <p>
     <a href="<?= $this->link ?>" class="tl_submit" onclick="Backend.getScrollOffset();Backend.openModalSelector({'width':768,'title':'<?= $this->translate('filepicker', 'MSC') ?>','url':this.href,'id':'<?= $this->id ?>'});return false"><?= $this->translate('changeSelection', 'MSC') ?></a>
 </p>
+</div>
 <?php if ($this->hasOrder): ?>
     <script>Backend.makeMultiSrcSortable("sort_<?= $this->id ?>", "ctrl_<?= $this->orderId ?>")</script>
 <?php endif; ?>

--- a/contao/templates/widget_treepicker_popup.html5
+++ b/contao/templates/widget_treepicker_popup.html5
@@ -1,4 +1,5 @@
-<ul class="tl_listing treepicker_popup<?php echo $this->class; ?>" id="<?php echo $this->id ?>">
+<div class="tl_listing_container tree_view unselectable" id="tl_select">
+<ul class="tl_listing treepicker_popup tree_view picker_selector <?php echo $this->class; ?>" id="<?php echo $this->id ?>">
 	<li class="tl_folder_top">
 		<div class="tl_left">
 			<?php echo $this->icon . $this->title; ?>
@@ -40,3 +41,4 @@
 	</ul>
 	</li>
 </ul>
+</div>

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/FileSelect.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/FileSelect.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2017 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2013-2017 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
+
+use Contao\Ajax;
+use Contao\Backend;
+use Contao\BackendTemplate;
+use Contao\BackendUser;
+use Contao\Config;
+use Contao\Database;
+use Contao\Environment;
+use Contao\FileSelector;
+use Contao\Input;
+use Contao\Session;
+use Contao\StringUtil;
+use Contao\System;
+use Contao\Validator;
+use Contao\Widget;
+use ContaoCommunityAlliance\DcGeneral\Contao\Callback\Callbacks;
+use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
+use ContaoCommunityAlliance\DcGeneral\Contao\InputProvider;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
+use ContaoCommunityAlliance\DcGeneral\DcGeneral;
+use ContaoCommunityAlliance\DcGeneral\Factory\DcGeneralFactory;
+use ContaoCommunityAlliance\Translator\Contao\LangArrayTranslator;
+use ContaoCommunityAlliance\Translator\TranslatorChain;
+
+/**
+ * Class FileSelect.
+ *
+ * Back end tree picker for usage in generalfile.php.
+ */
+class FileSelect
+{
+    /**
+     * Current ajax object.
+     *
+     * @var object
+     */
+    protected $objAjax;
+
+    /**
+     * The DcGeneral Object.
+     *
+     * @var DcGeneral
+     */
+    protected $itemContainer;
+
+    /**
+     * Initialize the controller.
+     *
+     * Sequence is:
+     * 1. Import the user.
+     * 2. Call the parent constructor
+     * 3. Authenticate the user
+     * 4. Load the language files
+     * DO NOT CHANGE THIS ORDER!
+     */
+    public function __construct()
+    {
+        BackendUser::getInstance();
+        Config::getInstance();
+        Session::getInstance();
+        Database::getInstance();
+
+        BackendUser::getInstance()->authenticate();
+
+        System::loadLanguageFile('default');
+        Backend::setStaticUrls();
+    }
+
+    /**
+     * Run the controller and parse the template.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
+     */
+    public function run()
+    {
+        $inputProvider = new InputProvider();
+
+        $template       = new BackendTemplate('be_picker');
+        $template->main = '';
+
+        // Ajax request.
+        // @codingStandardsIgnoreStart - We need POST access here.
+        if ($_POST && Environment::get('isAjaxRequest')) // @codingStandardsIgnoreEnd
+        {
+            $ajax = new Ajax(\Input::post('action'));
+            $ajax->executePreActions();
+        }
+
+        $modelId      = ModelId::fromSerialized($inputProvider->getParameter('id'));
+        $propertyName = $inputProvider->getParameter('field');
+
+        // Define the current ID.
+        define(
+            'CURRENT_ID',
+            ($modelId->getDataProviderName()
+                ? Session::getInstance()->get('CURRENT_ID') : $inputProvider->getParameter('id'))
+        );
+
+        $dispatcher = $GLOBALS['container']['event-dispatcher'];
+
+        $translator = new TranslatorChain();
+        $translator->add(new LangArrayTranslator($dispatcher));
+
+        $factory             = new DcGeneralFactory();
+        $this->itemContainer = $factory
+            ->setContainerName($modelId->getDataProviderName())
+            ->setTranslator($translator)
+            ->setEventDispatcher($dispatcher)
+            ->createDcGeneral();
+
+        $information = (array) $GLOBALS['TL_DCA'][$modelId->getDataProviderName()]['fields'][$propertyName];
+
+        if (!isset($information['eval'])) {
+            $information['eval'] = array();
+        }
+
+        // Merge with the information from the data container.
+        $property = $this
+            ->itemContainer
+            ->getEnvironment()
+            ->getDataDefinition()
+            ->getPropertiesDefinition()
+            ->getProperty($propertyName);
+        $extra    = $property->getExtra();
+
+        $information['eval'] = array_merge($extra, $information['eval']);
+
+        Session::getInstance()->set('filePickerRef', Environment::get('request'));
+
+        $fileSelectorValues = array();
+        foreach (array_filter(explode(',', $inputProvider->getParameter('value'))) as $k => $v) {
+            // Can be a UUID or a path
+            if (Validator::isStringUuid($v)) {
+                $fileSelectorValues[$k] = StringUtil::uuidToBin($v);
+            }
+        }
+
+        $activeModel = null;
+        if (Database::getInstance()->tableExists($modelId->getDataProviderName())) {
+            $dataProvider = $this->itemContainer->getEnvironment()->getDataProvider();
+
+            $activeModel = $dataProvider->fetch($dataProvider->getEmptyConfig()->setId($modelId->getId()));
+        }
+        $combat = new DcCompat($this->itemContainer->getEnvironment(), $activeModel, $propertyName);
+
+        if (is_array($GLOBALS['TL_DCA'][$modelId->getDataProviderName()]['fields'][$propertyName]['load_callback'])) {
+            $callbacks = $GLOBALS['TL_DCA'][$modelId->getDataProviderName()]['fields'][$propertyName]['load_callback'];
+            foreach ($callbacks as $callback) {
+                if (is_array($callback)) {
+                    $fileSelectorValues =
+                        Callbacks::callArgs($callback, array($fileSelectorValues, $combat));
+                } elseif (is_callable($callback)) {
+                    $fileSelectorValues = $callback($fileSelectorValues, $combat);
+                }
+            }
+        }
+
+        /** @var FileSelector $fileSelector */
+        $fileSelector = new $GLOBALS['BE_FFL']['fileSelector'](
+            Widget::getAttributesFromDca(
+                $information,
+                $propertyName,
+                $fileSelectorValues,
+                $propertyName,
+                $modelId->getDataProviderName(),
+                $combat
+            ),
+            $combat
+        );
+        if (isset($information['eval']['extensions'])) {
+            $fileSelector->extensions = $information['eval']['extensions'];
+        }
+
+        // AJAX request.
+        if (isset($ajax)) {
+            $ajax->executePostActions($combat);
+        }
+
+        $template->main        = $fileSelector->generate();
+        $template->theme       = Backend::getTheme();
+        $template->base        = Environment::get('base');
+        $template->language    = $GLOBALS['TL_LANGUAGE'];
+        $template->title       = specialchars($GLOBALS['TL_LANG']['MSC']['treepicker']);
+        $template->charset     = $GLOBALS['TL_CONFIG']['characterSet'];
+        $template->addSearch   = $fileSelector->searchField;
+        $template->search      = $GLOBALS['TL_LANG']['MSC']['search'];
+        $template->action      = ampersand(Environment::get('request'));
+        $template->value       = Session::getInstance()->get('file_selector_search');
+        $template->manager     = $GLOBALS['TL_LANG']['MSC']['treepickerManager'];
+        $template->managerHref = '';
+
+        if ('tl_files' !== $inputProvider->getValue('do')
+            && (null === $GLOBALS['TL_DCA']['tl_files']['list']['sorting']['breadcrumb'])
+        ) {
+            Backend::addFilesBreadcrumb('tl_files_picker');
+        }
+        $template->breadcrumb = $GLOBALS['TL_DCA']['tl_files']['list']['sorting']['breadcrumb'];
+
+        $user = BackendUser::getInstance();
+        // Add the manager link.
+        if ($user->hasAccess('files', 'modules')) {
+            $template->manager     = $GLOBALS['TL_LANG']['MSC']['fileManager'];
+            $template->managerHref = 'contao/main.php?do=files&amp;popup=1';
+        }
+
+        if (Input::get('switch') && $user->hasAccess('page', 'modules')) {
+            $template->switch     = $GLOBALS['TL_LANG']['MSC']['pagePicker'];
+            $template->switchHref =
+                str_replace('contao/file.php', 'contao/page.php', ampersand(Environment::get('request')));
+        }
+
+        // Prevent debug output at all cost.
+        $GLOBALS['TL_CONFIG']['debugMode'] = false;
+        $template->output();
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/Widget/FileTree.php
@@ -15,6 +15,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @author     Sven Baumann <baumann.sv@gmail.com>
  * @copyright  2013-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
@@ -22,8 +23,11 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Widget;
 
+use Contao\DataContainer;
+use Contao\RequestToken;
 use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ContaoBackendViewTemplate;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use Model\Collection;
 
 /**
@@ -258,7 +262,7 @@ class FileTree extends AbstractWidget
             return;
         }
 
-        foreach ($collection as $model) {
+        foreach ($collection->getModels() as $model) {
             // File system and database seem not in sync
             if (!file_exists(TL_ROOT . '/' . $model->path)) {
                 continue;
@@ -269,7 +273,7 @@ class FileTree extends AbstractWidget
                 continue;
             }
             if (false !== ($icon = $this->renderIcon($model, $this->isGallery, $this->isDownloads))) {
-                $icons[$model->uuid] = $icon;
+                $icons[] = ['uuid' => $model->uuid, 'image' => $icon];
             }
         }
     }
@@ -356,7 +360,7 @@ class FileTree extends AbstractWidget
      *
      * @param \File       $file  The image file being rendered.
      *
-     * @param $info
+     * @param string      $info  The image information.
      *
      * @return string
      */
@@ -416,13 +420,13 @@ class FileTree extends AbstractWidget
         $inputProvider = $this->getEnvironment()->getInputProvider();
 
         return sprintf(
-            'contao/file.php?do=%s&amp;table=%s&amp;field=%s&amp;act=show&amp;id=%s&amp;value=%s&amp;rt=%s',
+            '%s?do=%s&amp;field=%s&amp;act=show&amp;id=%s&amp;value=%s&amp;rt=%s',
+            'system/modules/dc-general/backend/generalfile.php',
             $inputProvider->getParameter('do'),
-            $this->getModel()->getProviderName(),
             $this->strField,
-            $this->getModel()->getId(),
+            $inputProvider->getParameter('id'),
             implode(',', $values),
-            \RequestToken::get()
+            RequestToken::get()
         );
     }
 
@@ -462,5 +466,63 @@ class FileTree extends AbstractWidget
         }
 
         return $buffer;
+    }
+
+    /**
+     * Update the value via ajax and redraw the widget.
+     *
+     * @param string        $ajaxAction    Not used in here.
+     *
+     * @param DataContainer $dataContainer The data container to use.
+     *
+     * @return string
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
+     * @SuppressWarnings(PHPMD.ExitExpression)
+     */
+    public function updateAjax($ajaxAction, DataContainer $dataContainer)
+    {
+        if ($ajaxAction !== 'loadFiletree') {
+            return '';
+        }
+
+        $this->dataContainer = $dataContainer;
+        $this->setUp();
+
+        $environment   = $this->dataContainer->getEnvironment();
+        $inputProvider = $environment->getInputProvider();
+        $propertyName  = $inputProvider->getValue('name');
+
+        $combat = new DcCompat($environment, null, $propertyName);
+
+        /** @var \FileSelector $widgetClass */
+        $widgetClass = $GLOBALS['BE_FFL']['fileSelector'];
+
+        /** @var \FileSelector $widget */
+        $widget = new $widgetClass(
+            $widgetClass::getAttributesFromDca(
+                $GLOBALS['TL_DCA'][$environment->getDataDefinition()->getName()]['fields'][$propertyName],
+                $combat->field,
+                null,
+                $propertyName,
+                $environment->getDataDefinition()->getName(),
+                $combat
+            )
+        );
+
+        // Load a particular node
+        if ('' !== $inputProvider->getValue('folder', true)) {
+            $buffer = $widget->generateAjax(
+                $inputProvider->getValue('folder', true),
+                $inputProvider->getValue('field'),
+                (int) $inputProvider->getValue('level')
+            );
+        } else {
+            $buffer = $widget->generate();
+        }
+
+        echo $buffer;
+        exit;
     }
 }


### PR DESCRIPTION
This is useful if you want to select a file and its property e. g. an onload callback is defined. In the callback method you want to use the active record, which is not supported before and now works. The data container is now a Dc-combat, before that the data container was a Dc-general.

This feature is the right implantation and replaced https://github.com/contao-community-alliance/dc-general/pull/368.