### PR TITLE
[WIP] Make the legacy model label callback listener compatible

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ModelLabelCallbackListener.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Callback/ModelLabelCallbackListener.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2015 Contao Community Alliance.
+ * (c) 2013-2017 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    contao-community-alliance/dc-general
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
- * @copyright  2013-2015 Contao Community Alliance.
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2013-2017 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -22,6 +23,8 @@ namespace ContaoCommunityAlliance\DcGeneral\Contao\Callback;
 
 use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\ModelToLabelEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ViewHelpers;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\GroupAndSortingInformationInterface;
 
 /**
  * Class ModelLabelCallbackListener.
@@ -52,11 +55,40 @@ class ModelLabelCallbackListener extends AbstractReturningCallbackListener
      *
      * @param ModelToLabelEvent $event The event being emitted.
      *
-     * @param string            $value The label text to use.
+     * @param string|array      $value The label text to use.
      *
      * @return void
      */
     public function update($event, $value)
+    {
+        $groupingInformation = ViewHelpers::getGroupingMode($event->getEnvironment());
+        if (isset($groupingInformation['mode'])
+            && ($groupingInformation['mode'] === GroupAndSortingInformationInterface::GROUP_NONE)
+        ) {
+            if (!is_array($value)) {
+                return;
+            }
+
+            $this->updateTableMode($event, $value);
+        }
+
+        if (!is_string($value)) {
+            return;
+        }
+
+        $this->updateNonTableMode($event, $value);
+    }
+
+    /**
+     * Set the value in the event.
+     *
+     * @param ModelToLabelEvent $event The event being emitted.
+     *
+     * @param string            $value The label text to use.
+     *
+     * @return void
+     */
+    private function updateNonTableMode(ModelToLabelEvent $event, $value)
     {
         if ($value === null) {
             return;
@@ -71,5 +103,45 @@ class ModelLabelCallbackListener extends AbstractReturningCallbackListener
         );
 
         $event->setLabel($value);
+    }
+
+    /**
+     * Set the value in the event.
+     *
+     * @param ModelToLabelEvent $event     The event being emitted.
+     *
+     * @param array             $arguments The label arguments.
+     *
+     * @return void
+     */
+    private function updateTableMode(ModelToLabelEvent $event, array $arguments)
+    {
+        if ($arguments === null
+            || empty($arguments)
+        ) {
+            return;
+        }
+
+        $updateArguments = $event->getArgs();
+
+        //Step 1 update arguments by index as propertyName
+        foreach ($event->getFormatter()->getPropertyNames() as $index => $propertyName) {
+            if (!isset($arguments[$propertyName])) {
+                continue;
+            }
+
+            $updateArguments[$propertyName] = $arguments[$propertyName];
+        }
+
+        //Step 2 update arguments by index as integer
+        foreach ($event->getFormatter()->getPropertyNames() as $index => $propertyName) {
+            if (!isset($arguments[$index])) {
+                continue;
+            }
+
+            $updateArguments[$propertyName] = $arguments[$index];
+        }
+
+        $event->setArgs($updateArguments);
     }
 }


### PR DESCRIPTION
The original table driver treats the label callback differently. In table mode, an array is expected as a return value. In the other modes, a string is expected as a return value.

See non table mode:
https://github.com/contao/core/blob/master/system/modules/core/drivers/DC_Table.php#L3732

See table mode:
https://github.com/contao/core/blob/master/system/modules/core/drivers/DC_Table.php#L4701