### PR TITLE
[INVALID] Trigger new ajax3 action before call the ajax3 handler

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
@@ -383,6 +383,9 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
      */
     public function handleAjaxCall()
     {
+        $event = new ActionEvent($this->environment, new Action('ajax3'));
+        $this->environment->getEventDispatcher()->dispatch(DcGeneralEvents::ACTION, $event);
+
         $handler = new Ajax3X();
         $handler->executePostActions(new DcCompat($this->getEnvironment()));
     }


### PR DESCRIPTION
This is useful e. g. for the MCW to register his own column properties, so that e. g. the file selector has to be loaded with the necessary configuration.