### PR TITLE
[INVALID] Redefine the parameter id if this isn´t model id conform

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/BaseView.php
@@ -34,6 +34,7 @@ use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetBr
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetGroupHeaderEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetSelectModeButtonsEvent;
 use ContaoCommunityAlliance\DcGeneral\Controller\Ajax3X;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\ContainerInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
@@ -383,6 +384,16 @@ class BaseView implements BackendViewInterface, EventSubscriberInterface
      */
     public function handleAjaxCall()
     {
+        $input = $this->environment->getInputProvider();
+
+        // Redefine the parameter id if this isn´t model id conform.
+        if (true === ($input->hasParameter('id'))
+            && (false === stripos($input->getParameter('id'), '::'))
+        ) {
+            $modelId = new ModelId($input->getParameter('table'), $input->getParameter('id'));
+            $input->setParameter('id', $modelId->getSerialized());
+        }
+
         $handler = new Ajax3X();
         $handler->executePostActions(new DcCompat($this->getEnvironment()));
     }


### PR DESCRIPTION
If have an ajax call of a non general table, we must redefine the url parameter id.
This problem can be review if you call the file or page picker