### PR TITLE
[RTM] Hotfix reset fallback PR #321

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FallbackResetSubscriber.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FallbackResetSubscriber.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2015 Contao Community Alliance.
+ * (c) 2013-2018 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,8 +12,9 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2013-2016 Contao Community Alliance.
- * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2013-2018 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
 
@@ -111,6 +112,11 @@ class FallbackResetSubscriber implements EventSubscriberInterface
                     // @codingStandardsIgnoreEnd
 
                     $dataProvider->resetFallback($propertyName);
+                }
+
+                // If value is empty, no need to reset the fallback.
+                if (!$model->getProperty($propertyName)) {
+                    continue;
                 }
 
                 $models = $dataProvider->fetchAll($config);


### PR DESCRIPTION
Hotfix reset fallback PR #321

see https://github.com/MetaModels/core/issues/1213

the implementation in PR #321 has a bug in https://github.com/contao-community-alliance/dc-general/blob/master/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FallbackResetSubscriber.php#L90

this method should reset the parameter e.g. "isdefault" only if the new item is set as default (=1)

```diff
    private function handleFallback(AbstractModelAwareEvent $event)
    {
        $model        = $event->getModel();
        $dataProvider = $event->getEnvironment()->getDataProvider($model->getProviderName());
        $properties   = $event->getEnvironment()->getDataDefinition()->getPropertiesDefinition();

        foreach (array_keys($model->getPropertiesAsArray()) as $propertyName) {
            if (!$properties->hasProperty($propertyName)) {
                continue;
            }

            $extra = (array) $properties->getProperty($propertyName)->getExtra();
            if (array_key_exists('fallback', $extra) && (true === $extra['fallback'])) {
                // BC Layer - use old reset fallback methodology until it get's removed.
                if (null === ($config = $this->determineFilterConfig($event))) {
                    // @codingStandardsIgnoreStart
                    @trigger_error(
                        'DataProviderInterface::resetFallback is deprecated - ' .
                        'Please specify proper parent child relationship',
                        E_USER_DEPRECATED
                    );
                    // @codingStandardsIgnoreEnd

                    $dataProvider->resetFallback($propertyName);
                }

+                if (!$model->getProperty($propertyName)) {
+                    continue;
+                }

                $models = $dataProvider->fetchAll($config);

                foreach ($models as $resetModel) {
                    if ($model->getId() === $resetModel->getId()) {
                        continue;
                    }
                    $resetModel->setProperty($propertyName, null);
                    $dataProvider->save($resetModel);
                }
            }
        }
    }
``