### PR TITLE
[RFC] Add empty value aware property information

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Dca/Builder/Legacy/LegacyDcaDataDefinitionBuilder.php
@@ -71,6 +71,7 @@ use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\DefaultPropertie
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\ModelRelationshipDefinitionInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\PalettesDefinitionInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\DefaultProperty;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\EmptyValueAwarePropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\BackCommand;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\Command;
@@ -1301,6 +1302,9 @@ class LegacyDcaDataDefinitionBuilder extends DcaReadingDataDefinitionBuilder
                     );
                     break;
 
+                case 'sql':
+                    $this->determineEmptyValueFromSql($property, $value);
+
                 default:
             }
         }
@@ -1590,5 +1594,48 @@ class LegacyDcaDataDefinitionBuilder extends DcaReadingDataDefinitionBuilder
         $this->evalFlagSorting($config, $flag);
         $this->evalFlagGrouping($config, $flag);
         $this->evalFlagGroupingLength($config, $flag);
+    }
+
+    /**
+     * Try to determine the empty type from SQL type.
+     *
+     * @param PropertyInterface $property The property to store the value into.
+     * @param string            $sqlType  The SQL type.
+     *
+     * @return void
+     */
+    private function determineEmptyValueFromSql(PropertyInterface $property, $sqlType)
+    {
+        if ($property instanceof EmptyValueAwarePropertyInterface) {
+            $property->setEmptyValue($this->getEmptyValueByFieldType($sqlType));
+        }
+    }
+
+    /**
+     * Return the empty value based on the SQL string.
+     *
+     * This method is backported from Contao 4.0 to have a value at hand.
+     *
+     * @param string $sql The SQL string.
+     *
+     * @return string|integer|null The empty value
+     */
+    private function getEmptyValueByFieldType($sql)
+    {
+        if (empty($sql)) {
+            return '';
+        }
+        if (stripos($sql, 'NOT NULL') === false) {
+            return null;
+        }
+        $type = strtolower(preg_replace('/^([A-Za-z]+)(\(| ).*$/', '$1', $sql));
+        if (\in_array(
+            $type,
+            ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'float', 'double', 'dec', 'decimal']
+        )
+        ) {
+            return 0;
+        }
+        return '';
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FallbackResetSubscriber.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/Subscriber/FallbackResetSubscriber.php
@@ -22,6 +22,7 @@
 namespace ContaoCommunityAlliance\DcGeneral\Contao\Subscriber;
 
 use ContaoCommunityAlliance\DcGeneral\Data\ConfigInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelManipulator;
 use ContaoCommunityAlliance\DcGeneral\Event\AbstractModelAwareEvent;
 use ContaoCommunityAlliance\DcGeneral\Event\PostDuplicateModelEvent;
 use ContaoCommunityAlliance\DcGeneral\Event\PostPersistModelEvent;
@@ -99,8 +100,8 @@ class FallbackResetSubscriber implements EventSubscriberInterface
             if (!$properties->hasProperty($propertyName)) {
                 continue;
             }
-
-            $extra = (array) $properties->getProperty($propertyName)->getExtra();
+            $property = $properties->getProperty($propertyName);
+            $extra    = (array) $property->getExtra();
             if (\array_key_exists('fallback', $extra) && (true === $extra['fallback'])) {
                 // BC Layer - use old reset fallback methodology until it get's removed.
                 if (null === ($config = $this->determineFilterConfig($event))) {
@@ -126,7 +127,7 @@ class FallbackResetSubscriber implements EventSubscriberInterface
                     if ($model->getId() === $resetModel->getId()) {
                         continue;
                     }
-                    $resetModel->setProperty($propertyName, null);
+                    $resetModel->setProperty($propertyName, ModelManipulator::sanitizeValue($property, null));
                     $dataProvider->save($resetModel);
                 }
             }

--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
@@ -38,17 +38,18 @@ use ContaoCommunityAlliance\DcGeneral\Clipboard\Item;
 use ContaoCommunityAlliance\DcGeneral\Clipboard\ItemInterface;
 use ContaoCommunityAlliance\DcGeneral\Contao\DataDefinition\Definition\Contao2BackendViewDefinitionInterface;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ViewHelpers;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\BasicDefinitionInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\EmptyValueAwarePropertyInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\GroupAndSortingInformationInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\CollectionInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\DataProviderInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\DefaultCollection;
 use ContaoCommunityAlliance\DcGeneral\Data\LanguageInformationInterface;
-use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
-use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\MultiLanguageDataProviderInterface;
-use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\BasicDefinitionInterface;
-use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
-use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\GroupAndSortingInformationInterface;
 use ContaoCommunityAlliance\DcGeneral\DcGeneralEvents;
 use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
 use ContaoCommunityAlliance\DcGeneral\Event\ActionEvent;
@@ -285,15 +286,16 @@ class DefaultController implements ControllerInterface
         }
         $environment = $this->getEnvironment();
         $properties  = $environment->getDataDefinition()->getPropertiesDefinition();
-        foreach ($propertyValues as $property => $value) {
+        foreach ($propertyValues as $propertyName => $value) {
             try {
-                if (!$properties->hasProperty($property)) {
+                if (!$properties->hasProperty($propertyName)) {
                     continue;
                 }
-                $extra = $properties->getProperty($property)->getExtra();
+                $property = $properties->getProperty($propertyName);
+                $extra    = $property->getExtra();
                 // Don´t save value if isset property readonly.
                 if (empty($extra['readonly'])) {
-                    $model->setProperty($property, $value);
+                    $model->setProperty($propertyName, $this->sanitizeValue($property, $value));
                 }
                 if (empty($extra)) {
                     continue;
@@ -302,15 +304,36 @@ class DefaultController implements ControllerInterface
                 if (!empty($extra['alwaysSave'])) {
                     // Set property to generate alias or combined values.
                     if (!empty($extra['readonly'])) {
-                        $model->setProperty($property, '');
+                        $model->setProperty($propertyName, '');
                     }
                     $model->setMeta($model::IS_CHANGED, true);
                 }
             } catch (\Exception $exception) {
-                $propertyValues->markPropertyValueAsInvalid($property, $exception->getMessage());
+                $propertyValues->markPropertyValueAsInvalid($propertyName, $exception->getMessage());
             }
         }
         return $this;
+    }
+
+    /**
+     * If value is empty, then override with the empty value stored in property information (if it has any).
+     *
+     * @param PropertyInterface $property The property information.
+     * @param mixed             $value    The value.
+     *
+     * @return mixed
+     */
+    private function sanitizeValue(PropertyInterface $property, $value)
+    {
+        // If value empty, then override with empty value in property (if it has any).
+        if (empty($value)
+            && ($property instanceof EmptyValueAwarePropertyInterface)
+            && $property->hasEmptyValue()
+        ) {
+            return $property->getEmptyValue();
+        }
+
+        return $value;
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Controller/DefaultController.php
@@ -40,8 +40,8 @@ use ContaoCommunityAlliance\DcGeneral\Contao\DataDefinition\Definition\Contao2Ba
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ViewHelpers;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelIdInterface;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelManipulator;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\BasicDefinitionInterface;
-use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\EmptyValueAwarePropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\GroupAndSortingInformationInterface;
 use ContaoCommunityAlliance\DcGeneral\Data\CollectionInterface;
@@ -286,54 +286,10 @@ class DefaultController implements ControllerInterface
         }
         $environment = $this->getEnvironment();
         $properties  = $environment->getDataDefinition()->getPropertiesDefinition();
-        foreach ($propertyValues as $propertyName => $value) {
-            try {
-                if (!$properties->hasProperty($propertyName)) {
-                    continue;
-                }
-                $property = $properties->getProperty($propertyName);
-                $extra    = $property->getExtra();
-                // Don´t save value if isset property readonly.
-                if (empty($extra['readonly'])) {
-                    $model->setProperty($propertyName, $this->sanitizeValue($property, $value));
-                }
-                if (empty($extra)) {
-                    continue;
-                }
-                // If always save is true, we need to mark the model as changed.
-                if (!empty($extra['alwaysSave'])) {
-                    // Set property to generate alias or combined values.
-                    if (!empty($extra['readonly'])) {
-                        $model->setProperty($propertyName, '');
-                    }
-                    $model->setMeta($model::IS_CHANGED, true);
-                }
-            } catch (\Exception $exception) {
-                $propertyValues->markPropertyValueAsInvalid($propertyName, $exception->getMessage());
-            }
-        }
+
+        ModelManipulator::updateModelFromPropertyBag($properties, $model, $propertyValues);
+
         return $this;
-    }
-
-    /**
-     * If value is empty, then override with the empty value stored in property information (if it has any).
-     *
-     * @param PropertyInterface $property The property information.
-     * @param mixed             $value    The value.
-     *
-     * @return mixed
-     */
-    private function sanitizeValue(PropertyInterface $property, $value)
-    {
-        // If value empty, then override with empty value in property (if it has any).
-        if (empty($value)
-            && ($property instanceof EmptyValueAwarePropertyInterface)
-            && $property->hasEmptyValue()
-        ) {
-            return $property->getEmptyValue();
-        }
-
-        return $value;
     }
 
     /**

--- a/src/ContaoCommunityAlliance/DcGeneral/Data/ModelManipulator.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Data/ModelManipulator.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2018 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @copyright  2013-2018 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Data;
+
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\EmptyValueAwarePropertyInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties\PropertyInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\PropertiesDefinitionInterface;
+
+/**
+ * This class provides methods to manipulate a model.
+ */
+class ModelManipulator
+{
+    /**
+     * Update the model with the values from the value bag.
+     *
+     * @param PropertiesDefinitionInterface $properties The property information store.
+     * @param ModelInterface                $model      The model to update.
+     * @param PropertyValueBagInterface     $values     The value bag to retrieve the values from.
+     *
+     * @return void
+     */
+    public static function updateModelFromPropertyBag(
+        PropertiesDefinitionInterface $properties,
+        ModelInterface $model,
+        PropertyValueBagInterface $values
+    ) {
+        foreach ($values as $propertyName => $value) {
+            try {
+                if (!$properties->hasProperty($propertyName)) {
+                    continue;
+                }
+
+                $property = $properties->getProperty($propertyName);
+                $extra    = $property->getExtra();
+                // Don´t save value if isset property readonly.
+                if (empty($extra['readonly'])) {
+                    $model->setProperty($propertyName, static::sanitizeValue($property, $value));
+                }
+
+                if (empty($extra)) {
+                    continue;
+                }
+
+                // If always save is true, we need to mark the model as changed.
+                if (!empty($extra['alwaysSave'])) {
+                    // Set property to generate alias or combined values.
+                    if (!empty($extra['readonly'])) {
+                        $model->setProperty($propertyName, static::sanitizeValue($property, null));
+                    }
+
+                    $model->setMeta($model::IS_CHANGED, true);
+                }
+            } catch (\Exception $exception) {
+                $values->markPropertyValueAsInvalid($propertyName, $exception->getMessage());
+            }
+        }
+    }
+
+    /**
+     * If value is empty, then override with the empty value stored in property information (if it has any).
+     *
+     * @param PropertyInterface $property The property information.
+     * @param mixed             $value    The value.
+     *
+     * @return mixed
+     */
+    public static function sanitizeValue(PropertyInterface $property, $value)
+    {
+        // If value empty, then override with empty value in property (if it has any).
+        if (empty($value)
+            && ($property instanceof EmptyValueAwarePropertyInterface)
+            && $property->hasEmptyValue()
+        ) {
+            return $property->getEmptyValue();
+        }
+
+        return $value;
+    }
+}

--- a/src/ContaoCommunityAlliance/DcGeneral/DataDefinition/Definition/Properties/DefaultProperty.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/DataDefinition/Definition/Properties/DefaultProperty.php
@@ -26,7 +26,7 @@ namespace ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties
  *
  * Default implementation of a property definition.
  */
-class DefaultProperty implements PropertyInterface
+class DefaultProperty implements PropertyInterface, EmptyValueAwarePropertyInterface
 {
     /**
      * The property name.
@@ -136,6 +136,20 @@ class DefaultProperty implements PropertyInterface
      * @var array
      */
     protected $extra = [];
+
+    /**
+     * Flag if an empty value has been set.
+     *
+     * @var bool
+     */
+    private $hasEmptyValue = false;
+
+    /**
+     * The empty value.
+     *
+     * @var mixed
+     */
+    private $emptyValue;
 
     /**
      * Create an instance.
@@ -333,5 +347,43 @@ class DefaultProperty implements PropertyInterface
     public function getExtra()
     {
         return $this->extra;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasEmptyValue()
+    {
+        return $this->hasEmptyValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEmptyValue()
+    {
+        return $this->emptyValue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEmptyValue($value)
+    {
+        $this->emptyValue    = $value;
+        $this->hasEmptyValue = true;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetEmptyValue()
+    {
+        $this->emptyValue    = null;
+        $this->hasEmptyValue = false;
+
+        return $this;
     }
 }

--- a/src/ContaoCommunityAlliance/DcGeneral/DataDefinition/Definition/Properties/EmptyValueAwarePropertyInterface.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/DataDefinition/Definition/Properties/EmptyValueAwarePropertyInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2018 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @copyright  2013-2018 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\Properties;
+
+/**
+ * This interface describes a property information that is aware of an empty value.
+ */
+interface EmptyValueAwarePropertyInterface
+{
+    /**
+     * Check if the property has an empty value.
+     *
+     * @return bool
+     */
+    public function hasEmptyValue();
+
+    /**
+     * Retrieve the empty value.
+     *
+     * @return mixed
+     */
+    public function getEmptyValue();
+
+    /**
+     * Set the empty value.
+     *
+     * @param mixed $value The value to set.
+     *
+     * @return static
+     */
+    public function setEmptyValue($value);
+
+    /**
+     * Reset an empty value.
+     *
+     * @return static
+     */
+    public function resetEmptyValue();
+}


### PR DESCRIPTION
## Description

This adds a new interface `EmptyValueAwarePropertyInterface` for properties to keep the ABI compatible.

The purpose of this property is to allow defining of an "empty" value which get's used instead of an empty string when saving property values.

This should help us to circumvent the MySQL strict mode problems we encounter currently.