### PR TITLE
[RFC] Feature save filtered session data in the database.

### DIFF
--- a/src/Contao/Dca/Populator/HardCodedPopulator.php
+++ b/src/Contao/Dca/Populator/HardCodedPopulator.php
@@ -73,10 +73,8 @@ class HardCodedPopulator extends AbstractEventDrivenEnvironmentPopulator
     {
         if (!$environment->getSessionStorage()) {
             $sessionStorage = \System::getContainer()->get('cca.dc-general.session');
-            $environment->setSessionStorage(
-                $sessionStorage
-                    ->createInstance('DC_GENERAL_' . \strtoupper($environment->getDataDefinition()->getName()))
-            );
+            $sessionStorage->setScope('DC_GENERAL_' . \strtoupper($environment->getDataDefinition()->getName()));
+            $environment->setSessionStorage($sessionStorage);
             // @codingStandardsIgnoreStart
             @\trigger_error('Fallback populator in use - implement a proper populator!', E_USER_DEPRECATED);
             // @codingStandardsIgnoreEnd

--- a/src/Contao/Factory/SessionStorageFactory.php
+++ b/src/Contao/Factory/SessionStorageFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2018 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @copyright  2013-2018 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\Factory;
+
+use ContaoCommunityAlliance\DcGeneral\Contao\SessionStorage;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * This factory create a new session storage
+ */
+class SessionStorageFactory
+{
+    /**
+     * The service container.
+     *
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * SessionStorageFactory constructor.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Create the session storage service.
+     *
+     * @return SessionStorage
+     */
+    public function createService()
+    {
+        return new SessionStorage(
+            $this->container->get('session'),
+            $this->container->getParameter('cca.dc-general.session.database_keys')
+        );
+    }
+}

--- a/src/Contao/SessionStorage.php
+++ b/src/Contao/SessionStorage.php
@@ -66,7 +66,7 @@ class SessionStorage implements SessionStorageInterface
      * @param array            $databaseKeys The database keys for store session data in the database.
      */
     public function __construct(
-        $key = '',
+        $key,
         SessionInterface $session,
         array $databaseKeys = []
     ) {

--- a/src/Contao/SessionStorage.php
+++ b/src/Contao/SessionStorage.php
@@ -65,13 +65,13 @@ class SessionStorage implements SessionStorageInterface
      *
      * @param RequestScopeDeterminator $scopeDeterminator The request scope determinator.
      * @param string                   $key               The key to use for storage.
-     * @param SessionInterface|null    $session           The symfony session.
+     * @param SessionInterface         $session           The symfony session.
      * @param array                    $databaseKeys      The database keys for store session data in the database.
      */
     public function __construct(
         RequestScopeDeterminator $scopeDeterminator = null,
         $key = '',
-        SessionInterface $session = null,
+        SessionInterface $session,
         array $databaseKeys = []
     ) {
         $this->key = (string) $key;
@@ -232,14 +232,10 @@ class SessionStorage implements SessionStorageInterface
         );
 
         if ($determineDatabase) {
-            $filter = \array_intersect_key($this->attributes, \array_flip($databaseAttributes));
-
-            return $filter;
+            return \array_intersect_key($this->attributes, \array_flip($databaseAttributes));
         }
 
-        $filter =  \array_diff_key($this->attributes, \array_flip($databaseAttributes));
-
-        return $filter;
+        return \array_diff_key($this->attributes, \array_flip($databaseAttributes));
     }
 
     /**

--- a/src/Contao/SessionStorage.php
+++ b/src/Contao/SessionStorage.php
@@ -30,8 +30,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class SessionStorage implements SessionStorageInterface
 {
-    use RequestScopeDeterminatorAwareTrait;
-
     /**
      * The session key.
      *
@@ -63,21 +61,18 @@ class SessionStorage implements SessionStorageInterface
     /**
      * Create a new instance.
      *
-     * @param RequestScopeDeterminator $scopeDeterminator The request scope determinator.
-     * @param string                   $key               The key to use for storage.
-     * @param SessionInterface         $session           The symfony session.
-     * @param array                    $databaseKeys      The database keys for store session data in the database.
+     * @param string           $key          The key to use for storage.
+     * @param SessionInterface $session      The symfony session.
+     * @param array            $databaseKeys The database keys for store session data in the database.
      */
     public function __construct(
-        RequestScopeDeterminator $scopeDeterminator = null,
         $key = '',
         SessionInterface $session,
         array $databaseKeys = []
     ) {
         $this->key = (string) $key;
 
-        $this->session           = $session;
-        $this->scopeDeterminator = $scopeDeterminator;
+        $this->session = $session;
 
         if (!\count($databaseKeys)) {
             return;
@@ -107,7 +102,7 @@ class SessionStorage implements SessionStorageInterface
      */
     public function createInstance($key)
     {
-        return new self($this->scopeDeterminator, $key, $this->session, $this->databaseKeys);
+        return new self($key, $this->session, $this->databaseKeys);
     }
 
     /**

--- a/src/Contao/SessionStorage.php
+++ b/src/Contao/SessionStorage.php
@@ -117,7 +117,7 @@ class SessionStorage implements SessionStorageInterface
     {
         $this->load();
 
-        return (bool) $this->attributes[$name];
+        return isset($this->attributes[$name]);
     }
 
     /**

--- a/src/Contao/SessionStorage.php
+++ b/src/Contao/SessionStorage.php
@@ -127,7 +127,7 @@ class SessionStorage implements SessionStorageInterface
     {
         $this->load();
 
-        return $this->attributes[$name];
+        return isset($this->attributes[$name]) ? $this->attributes[$name] : null;
     }
 
     /**

--- a/src/Contao/SessionStorage.php
+++ b/src/Contao/SessionStorage.php
@@ -156,7 +156,7 @@ class SessionStorage implements SessionStorageInterface
     public function replace(array $attributes)
     {
         $this->load();
-        $this->attributes = $attributes;
+        $this->attributes = \array_merge($this->attributes, $attributes);
         $this->persist();
         return $this;
     }

--- a/src/Contao/View/Contao2BackendView/TreePicker.php
+++ b/src/Contao/View/Contao2BackendView/TreePicker.php
@@ -1327,7 +1327,7 @@ class TreePicker extends Widget
 
         $tableName      = \explode('____', $this->getEnvironment()->getInputProvider()->getValue('name'))[0];
         $sessionKey     = 'DC_GENERAL_' . \strtoupper($tableName);
-        $sessionStorage = new SessionStorage($sessionKey);
+        $sessionStorage = new SessionStorage($sessionKey, $this->getEnvironment()->getSessionStorage());
 
         $selectAction = $this->getEnvironment()->getInputProvider()->getParameter('select');
 

--- a/src/Contao/View/Contao2BackendView/TreePicker.php
+++ b/src/Contao/View/Contao2BackendView/TreePicker.php
@@ -33,7 +33,6 @@ use ContaoCommunityAlliance\Contao\Bindings\Events\Backend\AddToUrlEvent;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Controller\ReloadEvent;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Image\GenerateHtmlEvent;
 use ContaoCommunityAlliance\DcGeneral\Contao\DataDefinition\Definition\Contao2BackendViewDefinitionInterface;
-use ContaoCommunityAlliance\DcGeneral\Contao\SessionStorage;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\ModelToLabelEvent;
 use ContaoCommunityAlliance\DcGeneral\Controller\TreeNodeStates;
 use ContaoCommunityAlliance\DcGeneral\Data\CollectionInterface;
@@ -1327,7 +1326,7 @@ class TreePicker extends Widget
 
         $tableName      = \explode('____', $this->getEnvironment()->getInputProvider()->getValue('name'))[0];
         $sessionKey     = 'DC_GENERAL_' . \strtoupper($tableName);
-        $sessionStorage = System::getContainer()->get('cca.dc-general.session')->createInstance($sessionKey);
+        $sessionStorage = System::getContainer()->get('cca.dc-general.session')->setScope($sessionKey);
 
         $selectAction = $this->getEnvironment()->getInputProvider()->getParameter('select');
 

--- a/src/Contao/View/Contao2BackendView/TreePicker.php
+++ b/src/Contao/View/Contao2BackendView/TreePicker.php
@@ -1327,7 +1327,7 @@ class TreePicker extends Widget
 
         $tableName      = \explode('____', $this->getEnvironment()->getInputProvider()->getValue('name'))[0];
         $sessionKey     = 'DC_GENERAL_' . \strtoupper($tableName);
-        $sessionStorage = new SessionStorage($sessionKey, $this->getEnvironment()->getSessionStorage());
+        $sessionStorage = System::getContainer()->get('cca.dc-general.session')->createInstance($sessionKey);
 
         $selectAction = $this->getEnvironment()->getInputProvider()->getParameter('select');
 

--- a/src/Contao/View/Contao2BackendView/TreeView.php
+++ b/src/Contao/View/Contao2BackendView/TreeView.php
@@ -66,7 +66,7 @@ class TreeView extends BaseView
      */
     protected function getToggleId()
     {
-        return $this->getEnvironment()->getDataDefinition()->getName() . '_tree';
+        return 'tree';
     }
 
     /**

--- a/src/Contao/View/Contao2BackendView/TreeView.php
+++ b/src/Contao/View/Contao2BackendView/TreeView.php
@@ -603,7 +603,7 @@ class TreeView extends BaseView
 
                 $user = BackendUser::getInstance();
 
-                Database::getInstance()->prepare('UPDATE tl_user SET session=? WHERE id=?')
+                Database::getInstance()->prepare('UPDATE tl_user SET tl_user.session=? WHERE tl_user.id=?')
                     ->execute(\serialize($sessionBag), $user->id);
                 // TODO END
                 exit;

--- a/src/Contao/View/Contao2BackendView/TreeView.php
+++ b/src/Contao/View/Contao2BackendView/TreeView.php
@@ -25,8 +25,12 @@
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
 use Contao\Backend;
+use Contao\BackendUser;
+use Contao\Database;
 use Contao\StringUtil;
 use Contao\Config;
+use Contao\System;
+use Contao\User;
 use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Backend\AddToUrlEvent;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Image\GenerateHtmlEvent;
@@ -584,12 +588,24 @@ class TreeView extends BaseView
 
         switch ($input->getValue('action')) {
             case 'DcGeneralLoadSubTree':
+                // TODO load sub as route (entry point).
                 \header('Content-Type: text/html; charset=' . Config::get('characterSet'));
                 echo $this->ajaxTreeView(
                     $input->getValue('id'),
                     $input->getValue('providerName'),
                     $input->getValue('level')
                 );
+
+                // TODO START give the response back or use own entry point for ajax call.
+                // The problem is the session will be update by event kernel.response.
+                $session = System::getContainer()->get('session');
+                $sessionBag = $session->getBag('contao_backend')->all();
+
+                $user = BackendUser::getInstance();
+
+                Database::getInstance()->prepare('UPDATE tl_user SET session=? WHERE id=?')
+                    ->execute(\serialize($sessionBag), $user->id);
+                // TODO END
                 exit;
 
             default:

--- a/src/Controller/Ajax.php
+++ b/src/Controller/Ajax.php
@@ -22,6 +22,9 @@
 namespace ContaoCommunityAlliance\DcGeneral\Controller;
 
 use Contao\Ajax as ContaoAjax;
+use Contao\BackendUser;
+use Contao\Database;
+use Contao\System;
 use ContaoCommunityAlliance\DcGeneral\Contao\Compatibility\DcCompat;
 use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\DataContainerInterface;
@@ -273,6 +276,16 @@ abstract class Ajax implements EnvironmentAwareInterface
      */
     protected function exitScript()
     {
+        // TODO START give the response back or use own entry point for ajax call.
+        // The problem is the session will be update by event kernel.response.
+        $session = System::getContainer()->get('session');
+        $sessionBag = $session->getBag('contao_backend')->all();
+
+        $user = BackendUser::getInstance();
+
+        Database::getInstance()->prepare('UPDATE tl_user SET session=? WHERE id=?')
+            ->execute(\serialize($sessionBag), $user->id);
+        // TODO END
         exit;
     }
 }

--- a/src/Controller/Ajax.php
+++ b/src/Controller/Ajax.php
@@ -283,7 +283,7 @@ abstract class Ajax implements EnvironmentAwareInterface
 
         $user = BackendUser::getInstance();
 
-        Database::getInstance()->prepare('UPDATE tl_user SET session=? WHERE id=?')
+        Database::getInstance()->prepare('UPDATE tl_user SET tl_user.session=? WHERE tl_user.id=?')
             ->execute(\serialize($sessionBag), $user->id);
         // TODO END
         exit;

--- a/src/DependencyInjection/CcaDcGeneralExtension.php
+++ b/src/DependencyInjection/CcaDcGeneralExtension.php
@@ -52,6 +52,7 @@ class CcaDcGeneralExtension extends Extension
         'contao/populater_common_listeners.yml',
         'contao/widget_backend_listeners.yml',
         'backend_event_subscribers.yml',
+        'config.yml',
         'event_listeners.yml',
         'services.yml'
     ];

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -1,0 +1,21 @@
+parameters:
+    # The database keys for the session is for save the key value in the database.
+    # This is useful for if come back and some settings have back.
+    #
+    # The common area is for provide in all tables.
+    # You can define keys for work by once table you will use as area name the table name.
+    # table_foo:
+    #     - foo_key
+    #     - bar_key
+    #
+    # The keys can you extend with the dependency injection in the build process from the symfony container.
+    cca.dc-general.session.database_keys:
+        common:
+            - LEGENDS
+            - CLIPBOARD
+            - tree
+            - sorting
+            - search
+            - limit
+            - filter
+            - dc_general

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,7 +20,6 @@ services:
         class: ContaoCommunityAlliance\DcGeneral\Contao\SessionStorage
         public: true
         arguments:
-            - "@cca.dc-general.scope-matcher"
             - ""
             - "@session"
             - "%cca.dc-general.session.database_keys%"

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -20,8 +20,10 @@ services:
         class: ContaoCommunityAlliance\DcGeneral\Contao\SessionStorage
         public: true
         arguments:
+            - "@cca.dc-general.scope-matcher"
             - ""
             - "@session"
+            - "%cca.dc-general.session.database_keys%"
 
     cca.dc-general.session_attribute:
         class: Contao\CoreBundle\Session\Attribute\ArrayAttributeBag

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -16,13 +16,16 @@ services:
         class: ContaoCommunityAlliance\DcGeneral\DefaultEnvironment
         public: false
 
+    cca.dc-general.session_factory:
+        class: ContaoCommunityAlliance\DcGeneral\Contao\Factory\SessionStorageFactory
+        arguments:
+            - "@service_container"
+        public: true
+
     cca.dc-general.session:
         class: ContaoCommunityAlliance\DcGeneral\Contao\SessionStorage
+        factory: cca.dc-general.session_factory:createService
         public: true
-        arguments:
-            - ""
-            - "@session"
-            - "%cca.dc-general.session.database_keys%"
 
     cca.dc-general.session_attribute:
         class: Contao\CoreBundle\Session\Attribute\ArrayAttributeBag


### PR DESCRIPTION
The database keys for the session is for save the key value in the database. This is useful for if come back and some settings have back.

The common area is for provide in all tables. You can define keys for work by once table you will use as area name the table name.
```yml
table_foo:
     - foo_key
     - bar_key
```
The keys can you extend with the dependency injection in the build process from the symfony container.