### PR TITLE
Display disabled icons for copy, delete, add etc. 

### DIFF
--- a/src/Contao/View/Contao2BackendView/ButtonRenderer.php
+++ b/src/Contao/View/Contao2BackendView/ButtonRenderer.php
@@ -16,6 +16,7 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2018 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource

--- a/src/Contao/View/Contao2BackendView/ButtonRenderer.php
+++ b/src/Contao/View/Contao2BackendView/ButtonRenderer.php
@@ -23,6 +23,7 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
+use Contao\Image;
 use Contao\StringUtil;
 use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Backend\AddToUrlEvent;
@@ -325,8 +326,15 @@ class ButtonRenderer
         }
 
         if ($buttonEvent->isDisabled()) {
+            $iconDisabledSuffix = '_1';
+
+            // Check wheter icon is part of contao
+            if ($icon !== Image::getPath($icon)) {
+                $iconDisabledSuffix = '_';
+            }
+
             return $this->renderImageAsHtml(
-                \substr_replace($icon, '_1', \strrpos($icon, '.'), 0),
+                \substr_replace($icon, $iconDisabledSuffix, \strrpos($icon, '.'), 0),
                 $buttonEvent->getLabel()
             );
         }


### PR DESCRIPTION
Check whether icon is part of the contao theme. If so, use a different suffix fo the disabled icon.

This actually is a hotifx.
Prior this commit, the disabled versions of delete.svg, copy.svg etc weren't displayed because such icons use `_.svg` as a suffix and not `_1.svg`

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
