### PR TITLE
[RFC] [2.2] Convert Timestamp for date widgets

### DIFF
--- a/src/Contao/View/Contao2BackendView/EventListener/ConvertTimestampWidgetListener.php
+++ b/src/Contao/View/Contao2BackendView/EventListener/ConvertTimestampWidgetListener.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2018 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2013-2018 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EventListener;
+
+
+use Contao\Config;
+use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
+use ContaoCommunityAlliance\Contao\Bindings\Events\Date\ParseDateEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\DecodePropertyValueForWidgetEvent;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\EncodePropertyValueFromWidgetEvent;
+
+class ConvertTimestampWidgetListener
+{
+
+    /**
+     * Encode an timestamp attribute value from a widget value.
+     *
+     * @param EncodePropertyValueFromWidgetEvent $event The subscribed event.
+     *
+     * @return void
+     */
+    public function handleEncodePropertyValueFromWidget(EncodePropertyValueFromWidgetEvent $event)
+    {
+        $environment        = $event->getEnvironment();
+        $dataDefinition     = $environment->getDataDefinition();
+        $propertyDefinition = $dataDefinition->getPropertiesDefinition()->getProperty($event->getProperty());
+
+        $extra = $propertyDefinition->getExtra();
+        $rgxp  = $extra['rgxp'];
+        if (!\in_array($rgxp, ['date', 'time', 'datim'])) {
+            return;
+        }
+
+        $date = \DateTime::createFromFormat($this->getDateTimeFormat($rgxp), $event->getValue());
+
+        if ($date) {
+            $event->setValue($date->getTimestamp());
+        }
+    }
+
+    /**
+     * Decode an timestamp attribute value for a widget value.
+     *
+     * @param DecodePropertyValueForWidgetEvent $event The subscribed event.
+     *
+     * @return void
+     */
+    public function handleDecodePropertyValueForWidgetEvent(DecodePropertyValueForWidgetEvent $event)
+    {
+        $environment        = $event->getEnvironment();
+        $dataDefinition     = $environment->getDataDefinition();
+        $propertyDefinition = $dataDefinition->getPropertiesDefinition()->getProperty($event->getProperty());
+
+        $extra = $propertyDefinition->getExtra();
+        $rgxp  = $extra['rgxp'];
+        if (!\in_array($rgxp, ['date', 'time', 'datim'])) {
+            return;
+        }
+
+        $dispatcher = $event->getEnvironment()->getEventDispatcher();
+        $value      = $event->getValue();
+
+        if (\is_numeric($value)) {
+            $dateEvent = new ParseDateEvent($value, $this->getDateTimeFormat($rgxp));
+            $dispatcher->dispatch(ContaoEvents::DATE_PARSE, $dateEvent);
+
+            $event->setValue($dateEvent->getResult());
+        }
+    }
+
+    private function getDateTimeFormat($format)
+    {
+        return Config::get($format.'Format');
+    }
+}

--- a/src/Resources/config/contao/widget_backend_listeners.yml
+++ b/src/Resources/config/contao/widget_backend_listeners.yml
@@ -19,3 +19,13 @@ services:
             -   name: kernel.event_listener
                 event: dc-general.view.contao2backend.build-widget
                 method: handleEvent
+
+    cca.dc-general.backend_listener.convert_timestamp_widget:
+        class: ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EventListener\ConvertTimestampWidgetListener
+        tags:
+            -   name: kernel.event_listener
+                event: dc-general.view.contao2backend.decode-property-value-for-widget
+                method: handleDecodePropertyValueForWidgetEvent
+            -   name: kernel.event_listener
+                event: dc-general.view.contao2backend.encode-property-value-from-widget
+                method: handleEncodePropertyValueFromWidget


### PR DESCRIPTION
## Description

Convert date widget values to timestamps on encode property value and vice-versa on decode property value.

Closes #415.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues

This code is simliar to https://github.com/MetaModels/attribute_timestamp/blob/2.0.4/src/MetaModels/Attribute/Timestamp/BootSubscriber.php#L56-L100

We need to ensure that both event listeners (the one of DCG and the one of MM) do not conflict.