### PR TITLE
Revert "Save the model by create action in two steps"

### DIFF
--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ActionHandler/CreateHandler.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/ActionHandler/CreateHandler.php
@@ -15,6 +15,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2018 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -26,7 +27,6 @@ use ContaoCommunityAlliance\DcGeneral\Contao\DataDefinition\Definition\Contao2Ba
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\BaseView;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EditMask;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ViewHelpers;
-use ContaoCommunityAlliance\DcGeneral\Data\ModelId;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\BackCommand;
 use ContaoCommunityAlliance\DcGeneral\View\ActionHandler\AbstractHandler;
 
@@ -87,37 +87,7 @@ class CreateHandler extends AbstractHandler
             return;
         }
 
-        // Initial for save the model in two steps.
-        if ($inputProvider->hasValue('save')
-            || $inputProvider->hasValue('saveNclose')
-            || $inputProvider->hasValue('saveNcreate')
-            || $inputProvider->hasValue('saveNback')
-        ) {
-            $inputProvider->setValue('doNotSubmit', true);
-        }
-
-        if ('select' !== $inputProvider->getParameter('act')) {
-            $this->handleGlobalCommands();
-        }
-
         $editMask = new EditMask($view, $model, $clone, null, null, $view->breadcrumb());
-        $response = $editMask->execute();
-        if (!$inputProvider->hasValue('doNotSubmit')) {
-            $event->setResponse($response);
-
-            return;
-        }
-
-        // Save the model step two. So as example alias or combined values work.
-        if ($inputProvider->hasValue('doNotSubmit')) {
-            $inputProvider->setValue('doNotSubmit', false);
-        }
-
-        $modelId       = ModelId::fromModel($model);
-        $newModel      = $dataProvider->fetch($dataProvider->getEmptyConfig()->setId($modelId->getId()));
-        $originalModel = clone $newModel;
-
-        $editMask = new EditMask($view, $newModel, $originalModel, null, null, $view->breadcrumb());
         $event->setResponse($editMask->execute());
     }
 

--- a/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/EditMask.php
+++ b/src/ContaoCommunityAlliance/DcGeneral/Contao/View/Contao2BackendView/EditMask.php
@@ -503,10 +503,6 @@ class EditMask
         $dispatcher    = $environment->getEventDispatcher();
         $inputProvider = $environment->getInputProvider();
 
-        if ($inputProvider->hasValue('doNotSubmit') && $inputProvider->getValue('doNotSubmit')) {
-            return;
-        }
-
         if ($inputProvider->hasValue('save')) {
             $newUrlEvent = new AddToUrlEvent('act=edit&id=' . ModelId::fromModel($model)->getSerialized());
             $dispatcher->dispatch(ContaoEvents::BACKEND_ADD_TO_URL, $newUrlEvent);


### PR DESCRIPTION
This reverts commit 42d97de01ac53dbaf2cf10cf8bc5615c0b5d9649.

Depends on MetaModels/core#1247.

## Description

Please explain the detailed changes you made here.
Reference any issue number this pull request fixes.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
