### PR TITLE
2 Hotfixes concerning the filter

### DIFF
--- a/src/Data/DefaultDataProvider.php
+++ b/src/Data/DefaultDataProvider.php
@@ -519,7 +519,7 @@ class DefaultDataProvider implements DataProviderInterface
     {
         $sorting = [];
         foreach ($config->getSorting() as $property => $value) {
-            if (0 === \strpos($property, $this->strSource . '.')) {
+            if (0 === \strpos($property, $this->source . '.')) {
                 $sorting[$property] = $value;
 
                 continue;
@@ -529,7 +529,7 @@ class DefaultDataProvider implements DataProviderInterface
                 continue;
             }
 
-            $sorting[$this->strSource . '.' . $property] = $value;
+            $sorting[$this->source . '.' . $property] = $value;
         }
         $config->setSorting($sorting);
     }
@@ -545,10 +545,10 @@ class DefaultDataProvider implements DataProviderInterface
     {
         foreach ($filter as &$child) {
             if (\array_key_exists('property', $child)
-                && (false === \strpos($child['property'], $this->strSource . '.'))
+                && (false === \strpos($child['property'], $this->source . '.'))
                 && $this->fieldExists($child['property'])
             ) {
-                $child['property'] = $this->strSource . '.' . $child['property'];
+                $child['property'] = $this->source . '.' . $child['property'];
             }
 
             if (\array_key_exists('children', $child)) {
@@ -567,13 +567,13 @@ class DefaultDataProvider implements DataProviderInterface
     private function fieldPrefixer(array &$fields)
     {
         foreach ($fields as $index => $property) {
-            if (0 === \strpos($property, $this->strSource . '.')
+            if (0 === \strpos($property, $this->source . '.')
                 || !$this->fieldExists($property)
             ) {
                 continue;
             }
 
-            $fields[$index] = $this->strSource . '.' . $property;
+            $fields[$index] = $this->source . '.' . $property;
         }
     }
 

--- a/src/Data/DefaultDataProvider.php
+++ b/src/Data/DefaultDataProvider.php
@@ -22,6 +22,7 @@
  * @author     Christopher Boelter <christopher@boelter.eu>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource

--- a/src/Data/DefaultDataProviderDBalUtils.php
+++ b/src/Data/DefaultDataProviderDBalUtils.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2018 Contao Community Alliance.
+ * (c) 2013-2019 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -12,7 +12,8 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2018 Contao Community Alliance.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */

--- a/src/Data/DefaultDataProviderDBalUtils.php
+++ b/src/Data/DefaultDataProviderDBalUtils.php
@@ -315,11 +315,13 @@ class DefaultDataProviderDBalUtils
      */
     private static function filterComparing($operation, QueryBuilder $queryBuilder)
     {
-        $queryBuilder->setParameter(':' . $operation['property'], $operation['value']);
-
         return $queryBuilder
             ->expr()
-            ->comparison($operation['property'], $operation['operation'], ':' . $operation['property']);
+            ->comparison(
+                $operation['property'],
+                $operation['operation'],
+                $queryBuilder->createNamedParameter($operation['value'])
+            );
     }
 
     /**


### PR DESCRIPTION
## Description

This PR holds two hotfixes.

At first, it fixes a typo resulting from a refactoring.
This resolves the error:
```
An exception occurred while executing 'SELECT DISTINCT(.offer) FROM tl_my_table WHERE .offer = :.offer':
```
Note the `.`!

Secondly, I switched to the `QueryBuilder::createNamedParameter` method, to prevent potential malicious characters in the property name.

```sql
SELECT DISTINCT(tl_my_table.offer) FROM tl_my_table WHERE tl_my_table.offer = :tl_my_table.offer
```
`:tl_my_table.offer` is not allowed as parameter name, therefore, using `QueryBuilder::createNamedParameter` is going to fix this.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
