### PR TITLE
Quote column names in select and do not add id property twice.

### DIFF
--- a/src/Data/DefaultDataProviderDBalUtils.php
+++ b/src/Data/DefaultDataProviderDBalUtils.php
@@ -47,9 +47,18 @@ class DefaultDataProviderDBalUtils
         }
 
         if (null !== $config->getFields()) {
-            $fields = implode(', ', $config->getFields());
+            $connection = $queryBuilder->getConnection();
+            $fields     = implode(
+                ', ',
+                array_map(
+                    function ($field) use ($connection) {
+                        return $connection->quoteIdentifier($field);
+                    },
+                    $config->getFields()
+                )
+            );
 
-            if (false !== stripos($fields, 'DISTINCT')) {
+            if (false !== stripos($fields, 'DISTINCT') || \in_array($idProperty, $config->getFields(), true)) {
                 $queryBuilder->select($fields);
                 return;
             }


### PR DESCRIPTION
## Description

Quote column names in select and do not add id property twice.

Fixes https://sentry.io/share/issue/e16a1d84dcf14ba999189a0e07cd5313/.

```
An exception occurred while executing 'SELECT id, id, pid, sorting, tstamp, published, dcatype, attr_id, tl_class, legendhide, legendtitle, mandatory, alwaysSave, filterable, searchable, chosen, allowHtml, preserveTags, decodeEntities, rte, rows, cols, trailingSlash, spaceToUnderscore, includeBlankOption, submitOnChange, readonly, fe_widget, doNotOverwrite, useHomeDir, fallbackImage, select_as_radio, select_minLevel, select_maxLevel, tag_as_wizard, tag_minLevel, tag_maxLevel, rgxp, thumbnailSize FROM tl_metamodel_dcasetting WHERE tl_metamodel_dcasetting.id=?' with params ["117"]:

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'rows, cols, trailingSlash, spaceToUnderscore, includeBlankOption, submitOnChange' at line 1
```

Maybe `rows` or `cols` is a reserved keyword. Idk.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
