### PR TITLE
Set disabled attribute for checkbox and select being readonly

### DIFF
--- a/src/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
+++ b/src/Contao/View/Contao2BackendView/Subscriber/WidgetBuilder.php
@@ -473,6 +473,8 @@ class WidgetBuilder implements EnvironmentAwareInterface
 
         $propExtra['required'] = ('' === $value) && !empty($propExtra['mandatory']);
 
+        $propExtra = $this->setPropExtraDisabled($property, $propExtra);
+
         $widgetConfig = [
             'inputType' => $property->getWidgetType(),
             'label'     => [
@@ -512,5 +514,23 @@ class WidgetBuilder implements EnvironmentAwareInterface
         }
 
         return $prepareAttributes;
+    }
+
+    /**
+     * Set "disabled" attribute for certain widgets being readonly.
+     *
+     * @param PropertyInterface $property  The property for the widget.
+     * @param array             $propExtra The property extra.
+     *
+     * @return array
+     */
+    private function setPropExtraDisabled(PropertyInterface $property, array $propExtra): array
+    {
+        if ($propExtra['readonly'] && \in_array($property->getWidgetType(), ['checkbox', 'select', 'radio'], true)) {
+            $propExtra['disabled'] = true;
+            unset($propExtra['chosen']);
+        }
+
+        return $propExtra;
     }
 }


### PR DESCRIPTION
## Description

Set `disabled` attribute for checkbox and select being readonly.
Fixes MetaModels/core#567.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
