### PR TITLE
Remove legacy dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "php": "^7.1",
         "contao/core-bundle": "^4.4",
         "contao-community-alliance/translator": "^2.1",
-        "contao-community-alliance/dependency-container": "^2.0",
         "contao-community-alliance/events-contao-bindings": "^4.4",
         "contao-community-alliance/url-builder": "^1.3",
         "symfony/event-dispatcher": "^3.3 || ^4.0",

--- a/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/EditAllHandler.php
+++ b/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/EditAllHandler.php
@@ -19,6 +19,7 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler\MultipleHandler;
 
+use Contao\System;
 use ContaoCommunityAlliance\DcGeneral\Action;
 use ContaoCommunityAlliance\DcGeneral\Contao\RequestScopeDeterminator;
 use ContaoCommunityAlliance\DcGeneral\Contao\RequestScopeDeterminatorAwareTrait;
@@ -166,7 +167,7 @@ class EditAllHandler extends AbstractPropertyOverrideEditAllHandler
      */
     private function handleLegendCollapsed(array $fieldSets)
     {
-        $editInformation = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation = System::getContainer()->get('cca.dc-general.edit-information');
         if (!$editInformation->hasAnyModelError()) {
             return $fieldSets;
         }
@@ -372,7 +373,7 @@ class EditAllHandler extends AbstractPropertyOverrideEditAllHandler
         PropertyValueBagInterface $propertyValuesBag,
         EnvironmentInterface $environment
     ) {
-        $editInformation = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation = System::getContainer()->get('cca.dc-general.edit-information');
         $sessionValues   = $this->getEditPropertiesByModelId($action, ModelId::fromModel($model), $environment);
 
         $modelError = $editInformation->getModelError($editModel);

--- a/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/EditAllHandler.php
+++ b/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/EditAllHandler.php
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource

--- a/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/OverrideAllHandler.php
+++ b/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/OverrideAllHandler.php
@@ -19,6 +19,7 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler\MultipleHandler;
 
+use Contao\System;
 use Contao\Widget;
 use ContaoCommunityAlliance\DcGeneral\Action;
 use ContaoCommunityAlliance\DcGeneral\Contao\RequestScopeDeterminator;
@@ -81,7 +82,7 @@ class OverrideAllHandler extends AbstractPropertyOverrideEditAllHandler
     {
         $inputProvider   = $environment->getInputProvider();
         $translator      = $environment->getTranslator();
-        $editInformation = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation = System::getContainer()->get('cca.dc-general.edit-information');
 
         $renderInformation = new \ArrayObject();
 
@@ -116,7 +117,7 @@ class OverrideAllHandler extends AbstractPropertyOverrideEditAllHandler
                 'error'       => $renderInformation->offsetGet('error'),
                 'breadcrumb'  => $this->renderBreadcrumb($environment),
                 'editButtons' => $this->getEditButtons($action, $environment),
-                'noReload'    => (bool) $editInformation->hasAnyModelError($action, $environment)
+                'noReload'    => (bool) $editInformation->hasAnyModelError()
             ]
         );
     }

--- a/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/OverrideAllHandler.php
+++ b/src/Contao/View/Contao2BackendView/ActionHandler/MultipleHandler/OverrideAllHandler.php
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource

--- a/src/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
+++ b/src/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
@@ -23,6 +23,7 @@
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView;
 
 use Contao\BackendTemplate;
+use Contao\System;
 use ContaoCommunityAlliance\DcGeneral\Clipboard\Clipboard;
 use ContaoCommunityAlliance\DcGeneral\Contao\InputProvider;
 use ContaoCommunityAlliance\DcGeneral\DefaultEnvironment;
@@ -124,22 +125,19 @@ class ContaoBackendViewTemplate extends BackendTemplate implements ViewTemplateI
      *
      * @SuppressWarnings(PHPMD.Superglobals)
      */
-    public function getBackButton()
+    public function getBackButton(): string
     {
-        $container = $GLOBALS['container'];
-
-        $dataContainer  = $container['dc-general.data-definition-container'];
+        $dataContainer  = System::getContainer()->get('cca.dc-general.data-definition-container');
         $dataDefinition = $dataContainer->getDefinition($this->table);
 
         $environment = new DefaultEnvironment();
         $environment->setDataDefinition($dataDefinition);
-        $environment->setTranslator($container['translator']);
-        $environment->setEventDispatcher($container['event-dispatcher']);
+        $environment->setTranslator(System::getContainer()->get('cca.translator.contao_translator'));
+        $environment->setEventDispatcher(System::getContainer()->get('event_dispatcher'));
         $environment->setInputProvider(new InputProvider());
         $environment->setClipboard(new Clipboard());
 
-        $renderer = new GlobalButtonRenderer($environment);
-        return $renderer->render();
+        return (new GlobalButtonRenderer($environment))->render();
     }
 
     // @codingStandardsIgnoreStart

--- a/src/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
+++ b/src/Contao/View/Contao2BackendView/ContaoBackendViewTemplate.php
@@ -15,6 +15,7 @@
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource

--- a/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -18,6 +18,7 @@
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource

--- a/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -29,6 +29,7 @@ use Contao\Backend;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\Date;
 use Contao\Input;
+use Contao\System;
 use Contao\TemplateLoader;
 use Contao\Widget;
 use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\BuildWidgetEvent;
@@ -76,14 +77,12 @@ class ContaoWidgetManager
      *
      * @param EnvironmentInterface $environment The environment in use.
      * @param ModelInterface       $model       The model for which widgets shall be generated.
-     *
-     * @SuppressWarnings(PHPMD.Superglobals)
      */
     public function __construct(EnvironmentInterface $environment, ModelInterface $model)
     {
         $this->environment = $environment;
         $this->model       = $model;
-        $this->framework   = $GLOBALS['container']->getContainer()->get('contao.framework');
+        $this->framework   = System::getContainer()->get('contao.framework');
     }
 
     /**

--- a/src/Contao/View/Contao2BackendView/EditMask.php
+++ b/src/Contao/View/Contao2BackendView/EditMask.php
@@ -453,7 +453,7 @@ class EditMask
         $propertyDefinitions = $definition->getPropertiesDefinition();
         $isAutoSubmit        = ('auto' === $environment->getInputProvider()->getValue('SUBMIT_TYPE'));
         $legendStates        = $this->getLegendStates();
-        $editInformation     = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation     = System::getContainer()->get('cca.dc-general.edit-information');
 
         $fieldSets = [];
         $first     = true;
@@ -688,7 +688,7 @@ class EditMask
             if (!$this->allValuesUnique()) {
                 return false;
             }
-            $editInformation = $GLOBALS['container']['dc-general.edit-information'];
+            $editInformation = System::getContainer()->get('cca.dc-general.edit-information');
 
             // Save the model.
             $dataProvider->save($this->model, $editInformation->uniformTime());
@@ -714,7 +714,7 @@ class EditMask
         $environment     = $this->getEnvironment();
         $translator      = $environment->getTranslator();
         $dataProvider    = $environment->getDataProvider($this->model->getProviderName());
-        $editInformation = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation = System::getContainer()->get('cca.dc-general.edit-information');
 
         // Run each and check the unique flag.
         foreach ($this->getDataDefinition()->getPropertiesDefinition()->getPropertyNames() as $propertyName) {
@@ -763,7 +763,7 @@ class EditMask
         $palettesDefinition      = $definition->getPalettesDefinition();
         $submitted               = ($definition->getName() === $inputProvider->getValue('FORM_SUBMIT'));
         $isAutoSubmit            = ('auto' === $inputProvider->getValue('SUBMIT_TYPE'));
-        $editInformation         = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation         = System::getContainer()->get('cca.dc-general.edit-information');
 
         $widgetManager = new ContaoWidgetManager($environment, $this->model);
 

--- a/src/Contao/View/Contao2BackendView/FileSelect.php
+++ b/src/Contao/View/Contao2BackendView/FileSelect.php
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -28,7 +29,6 @@ use Contao\Database;
 use Contao\Environment;
 use Contao\FileSelector;
 use Contao\Input;
-use Contao\Session;
 use Contao\StringUtil;
 use Contao\System;
 use Contao\Validator;

--- a/src/Contao/View/Contao2BackendView/FileSelect.php
+++ b/src/Contao/View/Contao2BackendView/FileSelect.php
@@ -279,13 +279,11 @@ class FileSelect
      */
     private function setupItemContainer(ModelIdInterface $modelId)
     {
-        $dispatcher = $GLOBALS['container']['event-dispatcher'];
-
+        $dispatcher = System::getContainer()->get('event_dispatcher');
         $translator = new TranslatorChain();
         $translator->add(new LangArrayTranslator($dispatcher));
 
-        $factory             = new DcGeneralFactory();
-        $this->itemContainer = $factory
+        $this->itemContainer = (new DcGeneralFactory())
             ->setContainerName($modelId->getDataProviderName())
             ->setTranslator($translator)
             ->setEventDispatcher($dispatcher)

--- a/src/Contao/View/Contao2BackendView/TreeSelect.php
+++ b/src/Contao/View/Contao2BackendView/TreeSelect.php
@@ -109,7 +109,7 @@ class TreeSelect
         // Define the current ID.
         \define('CURRENT_ID', ($inputTable ? $sessionStorage->get('CURRENT_ID') : $inputId));
 
-        $dispatcher = $GLOBALS['container']['event-dispatcher'];
+        $dispatcher = System::getContainer()->get('event_dispatcher');
 
         $translator = new TranslatorChain();
         $translator->add(new LangArrayTranslator($dispatcher));

--- a/src/Contao/View/Contao2BackendView/TreeSelect.php
+++ b/src/Contao/View/Contao2BackendView/TreeSelect.php
@@ -14,6 +14,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -29,7 +29,6 @@ use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use ContaoCommunityAlliance\Contao\Bindings\CcaEventsContaoBindingsBundle;
 use ContaoCommunityAlliance\DcGeneral\CcaDcGeneralBundle;
 use ContaoCommunityAlliance\UrlBuilder\CcaUrlBuilderBundle;
-use DependencyInjection\Container\CcaDependencyInjectionBundle;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -48,7 +47,6 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
                 ->setLoadAfter(
                     [
                         ContaoCoreBundle::class,
-                        CcaDependencyInjectionBundle::class,
                         CcaEventsContaoBindingsBundle::class
                     ]
                 )

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -13,6 +13,7 @@
  * @package    contao-community-alliance/dc-general
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -21,7 +22,6 @@
 namespace ContaoCommunityAlliance\DcGeneral\ContaoManager;
 
 use Contao\CoreBundle\ContaoCoreBundle;
-use Contao\ManagerBundle\ContaoManagerBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;

--- a/src/DataDefinition/Palette/Builder/PaletteBuilder.php
+++ b/src/DataDefinition/Palette/Builder/PaletteBuilder.php
@@ -14,6 +14,7 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource

--- a/src/DataDefinition/Palette/Builder/PaletteBuilder.php
+++ b/src/DataDefinition/Palette/Builder/PaletteBuilder.php
@@ -21,6 +21,7 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\DataDefinition\Palette\Builder;
 
+use Contao\System;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\ConditionChainInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\ContainerInterface;
 use ContaoCommunityAlliance\DcGeneral\DataDefinition\Palette\Builder\Event\AddConditionEvent;
@@ -1300,14 +1301,10 @@ class PaletteBuilder
      * @return void
      *
      * @internal
-     *
-     * @SuppressWarnings(PHPMD.Superglobals)
-     * @SuppressWarnings(PHPMD.CamelCaseVariableName)
      */
-    protected function dispatchEvent(BuilderEvent $event)
+    protected function dispatchEvent(BuilderEvent $event): void
     {
-        /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
-        $dispatcher = $GLOBALS['container']['event-dispatcher'];
+        $dispatcher = System::getContainer()->get('event_dispatcher');
         $dispatcher->dispatch($event::NAME, $event);
     }
 }

--- a/src/View/ActionHandler/AbstractPropertyOverrideEditAllHandler.php
+++ b/src/View/ActionHandler/AbstractPropertyOverrideEditAllHandler.php
@@ -20,6 +20,7 @@
 namespace ContaoCommunityAlliance\DcGeneral\View\ActionHandler;
 
 use Contao\Environment;
+use Contao\System;
 use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Controller\RedirectEvent;
 use ContaoCommunityAlliance\Contao\Bindings\Events\System\GetReferrerEvent;
@@ -214,7 +215,7 @@ abstract class AbstractPropertyOverrideEditAllHandler extends AbstractPropertyVi
         \ArrayObject $renderInformation,
         EnvironmentInterface $environment
     ) {
-        $editInformation  = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation  = System::getContainer()->get('cca.dc-general.edit-information');
         $errorInformation = $editInformation->getModelError($model);
         if (null === $errorInformation) {
             return;
@@ -332,7 +333,7 @@ abstract class AbstractPropertyOverrideEditAllHandler extends AbstractPropertyVi
         EnvironmentInterface $environment
     ) {
         $inputProvider   = $environment->getInputProvider();
-        $editInformation = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation = System::getContainer()->get('cca.dc-general.edit-information');
 
         $inputValues = $this->handleInputValues($action, $model, $environment);
 
@@ -531,7 +532,7 @@ abstract class AbstractPropertyOverrideEditAllHandler extends AbstractPropertyVi
         EnvironmentInterface $environment
     ) {
         $propertiesDefinition = $environment->getDataDefinition()->getPropertiesDefinition();
-        $editInformation      = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation      = System::getContainer()->get('cca.dc-general.edit-information');
 
         $propertyValueBag = new PropertyValueBag();
 
@@ -674,7 +675,7 @@ abstract class AbstractPropertyOverrideEditAllHandler extends AbstractPropertyVi
         CollectionInterface $collection,
         EnvironmentInterface $environment
     ) {
-        $editInformation = $GLOBALS['container']['dc-general.edit-information'];
+        $editInformation = System::getContainer()->get('cca.dc-general.edit-information');
         if (!$editInformation->hasAnyModelError()) {
             return;
         }

--- a/src/View/ActionHandler/AbstractPropertyOverrideEditAllHandler.php
+++ b/src/View/ActionHandler/AbstractPropertyOverrideEditAllHandler.php
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/dc-general
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
  * @copyright  2013-2019 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0
  * @filesource


### PR DESCRIPTION
## Description

I removed the dependency on the package [`contao-community-alliance/dependency-container`](https://github.com/contao-community-alliance/dependency-container)
because it requires `pimple/pimple` in version 1.0. This conflicts with  [Deployer](https://github.com/deployphp/deployer), which requires Pimple in version 3.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
