### PR TITLE
[RTM] Do not add saveNclose if "nb" parameter given

### DIFF
--- a/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -361,9 +361,8 @@ class ContaoWidgetManager
         $this->widgetAddError($property, $widget, $inputValues, $ignoreErrors);
 
         $propInfo = $this->getEnvironment()->getDataDefinition()->getPropertiesDefinition()->getProperty($property);
-        $extra    = (array) $propInfo->getExtra();
 
-        $isHideInput = (isset($extra['hideInput']) ?? $extra['hideInput']);
+        $isHideInput = (bool) $widget->hideInput;
 
         $hiddenFields = ($isHideInput) ? $this->buildHiddenFields($widget->value, $widget->name) : null;
 

--- a/src/Contao/View/Contao2BackendView/EditMask.php
+++ b/src/Contao/View/Contao2BackendView/EditMask.php
@@ -347,19 +347,21 @@ class EditMask
         );
         $buttons['save'] = $buttonTemplate->parse();
 
-        $buttonTemplate->setData(
-            [
-                'label'      => $this->getButtonLabel('saveNclose'),
-                'attributes' => [
-                    'type'      => 'submit',
-                    'name'      => 'saveNclose',
-                    'id'        => 'saveNclose',
-                    'class'     => 'tl_submit',
-                    'accesskey' => 'c'
+        if (!$this->getEnvironment()->getInputProvider()->getParameter('nb')) {
+            $buttonTemplate->setData(
+                [
+                    'label'      => $this->getButtonLabel('saveNclose'),
+                    'attributes' => [
+                        'type'      => 'submit',
+                        'name'      => 'saveNclose',
+                        'id'        => 'saveNclose',
+                        'class'     => 'tl_submit',
+                        'accesskey' => 'c'
+                    ]
                 ]
-            ]
-        );
-        $buttons['saveNclose'] = $buttonTemplate->parse();
+            );
+            $buttons['saveNclose'] = $buttonTemplate->parse();
+        }
 
         if (!$this->isPopup() && $basicDefinition->isCreatable()) {
             $buttonTemplate->setData(

--- a/src/Contao/View/Contao2BackendView/EditMask.php
+++ b/src/Contao/View/Contao2BackendView/EditMask.php
@@ -363,7 +363,8 @@ class EditMask
             $buttons['saveNclose'] = $buttonTemplate->parse();
         }
 
-        if (!$this->isPopup() && $basicDefinition->isCreatable()) {
+        if ($basicDefinition->isCreatable()
+            && !$this->getEnvironment()->getInputProvider()->getParameter('nc')) {
             $buttonTemplate->setData(
                 [
                     'label'      => $this->getButtonLabel('saveNcreate'),


### PR DESCRIPTION
## Description

Same procedure as in DC_Table.
https://github.com/contao/contao/blob/812ac06cd1c6f6c775e0dbca2547d89b3be36a2d/core-bundle/src/Resources/contao/drivers/DC_Table.php#L2000

Useful if you have a popup link on an edit mask. In this case, you don't need a back link.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues