### PR TITLE
Add properties to table head if defined

### DIFF
--- a/src/Contao/View/Contao2BackendView/ActionHandler/AbstractListShowAllHandler.php
+++ b/src/Contao/View/Contao2BackendView/ActionHandler/AbstractListShowAllHandler.php
@@ -480,14 +480,11 @@ abstract class AbstractListShowAllHandler
         $sorting    = ViewHelpers::getCurrentSorting($environment);
         $columns    = $this->getSortingColumns($sorting);
         foreach ($formatter->getPropertyNames() as $field) {
-            // Skip unknown properties. This may happen if the property is not defined for editing but only listing.
-            if (!$properties->hasProperty($field)) {
-                continue;
-            }
-
             $tableHead[] = [
                 'class'   => 'tl_folder_tlist col_' . $field . (\in_array($field, $columns) ? ' ordered_by' : ''),
-                'content' => $properties->getProperty($field)->getLabel()
+                'content' => $properties->hasProperty($field)
+                    ? $properties->getProperty($field)->getLabel()
+                    : $this->translate($definition->getName() . '.' . $field . '.0', 'contao_' . $definition->getName())
             ];
         }
 

--- a/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -361,9 +361,8 @@ class ContaoWidgetManager
         $this->widgetAddError($property, $widget, $inputValues, $ignoreErrors);
 
         $propInfo = $this->getEnvironment()->getDataDefinition()->getPropertiesDefinition()->getProperty($property);
-        $extra    = (array) $propInfo->getExtra();
 
-        $isHideInput = (isset($extra['hideInput']) ?? $extra['hideInput']);
+        $isHideInput = (bool) $widget->hideInput;
 
         $hiddenFields = ($isHideInput) ? $this->buildHiddenFields($widget->value, $widget->name) : null;
 


### PR DESCRIPTION
## Description

I want to propose the following change:
"Add the properties to the table head if defined."

Reason:
I add custom properties via the `PopulateEnvironmentEvent`.
```php
       /** @var Contao2BackendViewDefinitionInterface $viewSection */
        $viewSection = $definition->getDefinition(Contao2BackendViewDefinitionInterface::NAME);
        $formatter   = $viewSection->getListingConfig()->getLabelFormatter($definition->getName());

        $propertyNames   = $formatter->getPropertyNames();
        $propertyNames[] = 'paid_status';
```

Then, the table looks like this (header `td` is missing):
<img width="865" alt="Screen Shot 2019-05-31 at 12 42 44" src="https://user-images.githubusercontent.com/1284725/58700866-a011b880-83a1-11e9-95e6-09132a65b8ff.png">

With my change, the table is correct:
<img width="867" alt="Screen Shot 2019-05-31 at 12 40 16" src="https://user-images.githubusercontent.com/1284725/58700880-aacc4d80-83a1-11e9-8a35-b33a8dfad243.png">



## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
