### PR TITLE
Fix grouping information in template.

### DIFF
--- a/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
+++ b/src/Contao/View/Contao2BackendView/ContaoWidgetManager.php
@@ -361,9 +361,8 @@ class ContaoWidgetManager
         $this->widgetAddError($property, $widget, $inputValues, $ignoreErrors);
 
         $propInfo = $this->getEnvironment()->getDataDefinition()->getPropertiesDefinition()->getProperty($property);
-        $extra    = (array) $propInfo->getExtra();
 
-        $isHideInput = (isset($extra['hideInput']) ?? $extra['hideInput']);
+        $isHideInput = (bool) $widget->hideInput;
 
         $hiddenFields = ($isHideInput) ? $this->buildHiddenFields($widget->value, $widget->name) : null;
 

--- a/src/Resources/contao/templates/dcbe_general_common_list.html5
+++ b/src/Resources/contao/templates/dcbe_general_common_list.html5
@@ -59,7 +59,7 @@ use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\View\GroupAndSor
 <?php if ($this->collection->length() > 0) : ?>
 <?php
 // If we are grouped, split them up.
-$this->grouped = ($this->mode !== GroupAndSortingInformationInterface::GROUP_NONE);
+$this->grouped = (null !== $this->mode && $this->mode !== GroupAndSortingInformationInterface::GROUP_NONE);
 if ($this->mode !== GroupAndSortingInformationInterface::GROUP_NONE) {
     $grouped = [];
     foreach ($this->collection as $model) {


### PR DESCRIPTION
## Description

The template shows a grouping header that does not belong here.
`null` is a valid value as of… (line 165)
https://github.com/contao-community-alliance/dc-general/blob/bf59fc2085cc848c564e40324dee14ef2897faa6/src/Contao/View/Contao2BackendView/ViewHelpers.php#L156-L166

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
