### PR TITLE
Change the handling of tl_limit for the DefaultLimitElement

### DIFF
--- a/src/Panel/DefaultLimitElement.php
+++ b/src/Panel/DefaultLimitElement.php
@@ -155,9 +155,11 @@ class DefaultLimitElement extends AbstractElement implements LimitElementInterfa
 
             $input = $this->getInputProvider();
             if ($input->hasValue('tl_limit') && $this->getPanel()->getContainer()->updateValues()) {
-                [$offset, $amount] = \explode(',', $input->getValue('tl_limit'));
-
-                $this->setPersistent($offset, $amount);
+                $limit = $input->getValue('tl_limit');
+                if ('tl_limit' !== $limit) {
+                    [$offset, $amount] = \explode(',', $input->getValue('tl_limit'));
+                    $this->setPersistent($offset, $amount);
+                }
             }
 
             $persistent = $this->getPersistent();


### PR DESCRIPTION
Behavior:
The value "tl_limit" of the limit field will be handled as "all". 

Problem: 
If you set up a filter with no result the selected value of the limit field will be 'tl_limit' if you now reset the filter back, the limit will still be "tl_limit" which mean i will get all result after a filter reload. So if you have 20k entries in the list, the system isn't able to display this data. 

Fix: 
I change the handling that the value "tl_limit" will be handled as nothing. So the system can use the default handling.