### PR TITLE
Force int value for "setOffset($offset)"

### DIFF
--- a/src/Panel/DefaultLimitElement.php
+++ b/src/Panel/DefaultLimitElement.php
@@ -243,7 +243,7 @@ class DefaultLimitElement extends AbstractElement implements LimitElementInterfa
      */
     public function setOffset($offset)
     {
-        $this->intOffset = $offset;
+        $this->intOffset = (int) $offset;
 
         return $this;
     }


### PR DESCRIPTION
Fix a problem where the value for setOffset($offset) is not a int value. This should fix the problem where the selected value of the limit select wasn't set correct.
