### PR TITLE
Add fallback for id property in tree picker

### DIFF
--- a/src/Contao/View/Contao2BackendView/TreePicker.php
+++ b/src/Contao/View/Contao2BackendView/TreePicker.php
@@ -1338,7 +1338,8 @@ class TreePicker extends Widget
             $this->generateToggleUrl($model)
         );
 
-        $template = new ContaoBackendViewTemplate('widget_treepicker_entry');
+        $idProperty = $this->idProperty ?: 'id';
+        $template   = new ContaoBackendViewTemplate('widget_treepicker_entry');
         $template
             ->setTranslator($this->getEnvironment()->getTranslator())
             ->set('id', $this->strId)
@@ -1351,8 +1352,8 @@ class TreePicker extends Widget
             ->set('toggleUrl', $this->generateToggleUrl($model))
             ->set('toggleTitle', $toggleTitle)
             ->set('toggleScript', $toggleScript)
-            ->set('active', static::optionChecked($model->getProperty($this->idProperty), $this->value))
-            ->set('idProperty', $this->idProperty);
+            ->set('active', static::optionChecked($model->getProperty($idProperty), $this->value))
+            ->set('idProperty', $idProperty);
 
         $level = $model->getMeta(DCGE::TREE_VIEW_LEVEL);
         if (($this->minLevel > 0) && ($level < ($this->minLevel - 1))) {


### PR DESCRIPTION
This adds the fallback to use `id` as id property if none has been defined as already used in `TreePicker::renderItemsPlain()`.

If no id property has been passed via URL, we get a popup display showing all entries as selected (as id property is `null`, the value of the property named `null` in the model is also `null` and hence we compare  `null == null` for testing if the id has been checked).
