### PR TITLE
Fix version data retrieval in DefaultDataProvider

### DIFF
--- a/src/Data/DefaultDataProvider.php
+++ b/src/Data/DefaultDataProvider.php
@@ -23,6 +23,7 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @author     Alex Wuttke <alex@das-l.de>
  * @copyright  2013-2020 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -742,8 +743,8 @@ class DefaultDataProvider implements DataProviderInterface
         $queryBuilder = $this->connection->createQueryBuilder();
         $queryBuilder->select(['tstamp', 'version', 'username', 'active']);
         $queryBuilder->from('tl_version');
-        $queryBuilder->andWhere($queryBuilder->expr()->eq('tl_version.formTable', ':formTable'));
-        $queryBuilder->setParameter(':formTable', $this->source);
+        $queryBuilder->andWhere($queryBuilder->expr()->eq('tl_version.fromTable', ':fromTable'));
+        $queryBuilder->setParameter(':fromTable', $this->source);
         $queryBuilder->andWhere($queryBuilder->expr()->eq('tl_version.pid', ':pid'));
         $queryBuilder->setParameter(':pid', $mixID);
 

--- a/src/Data/DefaultDataProvider.php
+++ b/src/Data/DefaultDataProvider.php
@@ -852,7 +852,7 @@ class DefaultDataProvider implements DataProviderInterface
     public function getActiveVersion($mixID)
     {
         $queryBuilder = $this->connection->createQueryBuilder();
-        $queryBuilder->select(['select']);
+        $queryBuilder->select('version');
         $queryBuilder->from('tl_version');
         $queryBuilder->andWhere($queryBuilder->expr()->eq('tl_version.pid', ':pid'));
         $queryBuilder->setParameter(':pid', $mixID);

--- a/src/Data/DefaultDataProvider.php
+++ b/src/Data/DefaultDataProvider.php
@@ -760,7 +760,7 @@ class DefaultDataProvider implements DataProviderInterface
             return null;
         }
 
-        $versions = $statement->fetch(\PDO::FETCH_ASSOC);
+        $versions = $statement->fetchAll(\PDO::FETCH_ASSOC);
 
         $collection = $this->getEmptyCollection();
 

--- a/src/Data/DefaultDataProvider.php
+++ b/src/Data/DefaultDataProvider.php
@@ -695,6 +695,7 @@ class DefaultDataProvider implements DataProviderInterface
     public function getVersion($mixID, $mixVersion)
     {
         $queryBuilder = $this->connection->createQueryBuilder();
+        $queryBuilder->select('*');
         $queryBuilder->from('tl_version');
         $queryBuilder->andWhere($queryBuilder->expr()->eq('tl_version.pid', ':pid'));
         $queryBuilder->setParameter(':pid', $mixID);


### PR DESCRIPTION
## Description

* `DefaultDataProvider#getVersions()` has typos: `formTable` instead of `fromTable`. `fetch()` should be `fetchAll()`, as is evident by subsequent iteration expecting result rows.
* `getActiveVersion` has a typo (`select(['select'])` should be selecting `'version'`).
* `getVersion()` is missing a select.

To quickly reproduce the issues, change `dataContainer` to `General` in any Contao core DCA that has versioning enabled, for example `tl_theme`. First exception coming from the `formTable` typo:

> An exception occurred while executing 'SELECT tstamp, version, username, active FROM tl_version WHERE (tl_version.formTable = ?) AND (tl_version.pid = ?) ORDER BY tl_version.version DESC' with params ["tl_theme", "1"]: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'tl_version.formTable' in 'where clause'

Other exceptions follow when editing and saving.

Introduced in 91f288aaf4c18787ef5e6f4fab9597e5cd2c122c.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
