### PR TITLE
Fixes problem with filter and search element in backend, that do not create an AND query

### DIFF
--- a/src/Panel/DefaultSearchElement.php
+++ b/src/Panel/DefaultSearchElement.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of contao-community-alliance/dc-general.
  *
- * (c) 2013-2019 Contao Community Alliance.
+ * (c) 2013-2020 Contao Community Alliance.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,7 +15,8 @@
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2019 Contao Community Alliance.
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
+ * @copyright  2013-2020 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -145,14 +146,9 @@ class DefaultSearchElement extends AbstractElement implements SearchElementInter
                 $currents,
                 [
                     [
-                        'operation' => 'AND',
-                        'children'  => [
-                            [
-                                'operation' => 'LIKE',
-                                'property'  => $this->getSelectedProperty(),
-                                'value'     => \sprintf('*%s*', $this->getValue())
-                            ]
-                        ]
+                        'operation' => 'LIKE',
+                        'property'  => $this->getSelectedProperty(),
+                        'value'     => \sprintf('*%s*', $this->getValue())
                     ]
                 ]
             )


### PR DESCRIPTION
## Description

Let's make an example:

- there is a model with a field `type` and a field `title`
- the `type` is a drop down which gets its values from another model
- in the backend list view I can filter by `type` and search by `title`
- using both, e.g. filtering für `type` value "A" and searching for `title` which contain "B", I want to see all records of `type` "A" **AND** with `title` "B"

- without this change, you get all records with `type` "A" **OR** with `title` "B"

As tested with @zonky2 this problem also exists in DCG 2.2.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
