### PR TITLE
Correctly define the backend list search input to add an `x` for deleting the input value

### DIFF
--- a/src/Resources/contao/templates/dcbe_general_panel_search.html5
+++ b/src/Resources/contao/templates/dcbe_general_panel_search.html5
@@ -6,5 +6,5 @@
 		<?php endforeach; ?>
 	</select>
 	<span> = </span>
-	<input type="text" name="tl_value" class="<?php echo $this->class; ?>" value="<?php echo $this->value; ?>">
+	<input type="search" name="tl_value" class="tl_text" value="<?php echo $this->value; ?>">
 </div>


### PR DESCRIPTION
## Description

This PR corrects the backend list search input field. This adds an `x` which can be used to delete the value of the field.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [-] Created tests, if possible
- [x] All tests passing
- [-] Extended the README / documentation, if necessary
- [-] Added myself to the `@authors` in touched PHP files
- [-] Checked the changes with phpcq and introduced no new issues
