### PR TITLE
Fix for paste button

### DIFF
--- a/src/Controller/ModelCollector.php
+++ b/src/Controller/ModelCollector.php
@@ -437,7 +437,9 @@ class ModelCollector
 
         foreach ($this->relationships->getChildConditions() as $condition) {
             // Skip conditions where the destination is not the provider
-            if ($this->defaultProviderName !== $condition->getDestinationName()) {
+            if ($this->defaultProviderName !== $condition->getDestinationName()
+                || $this->defaultProviderName !== $condition->getSourceName()
+            ) {
                 continue;
             }
 


### PR DESCRIPTION
Fix an error where the hierarchical detection find the wrong condition and
used the parent id list instead of the hierarchical one.