### PR TITLE
Fix empty id in URL with new HTLM encoding in Contao 4.9

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -24,3 +24,4 @@ mapping:
   "Ingolf Steinhardt <info@e-spin.de>":
     - "xantippe <info@e-spin.de>"
     - "zonky2 <info@e-spin.de>"
+    - "e-spin <git@e-spin.de>"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build/
 # PHPCQ and related tools
 .php_cs.cache
 build.properties
+.build

--- a/src/Contao/View/Contao2BackendView/EditMask.php
+++ b/src/Contao/View/Contao2BackendView/EditMask.php
@@ -605,7 +605,7 @@ class EditMask
         $inputProvider = $environment->getInputProvider();
 
         if ($inputProvider->hasValue('save')) {
-            $newUrlEvent = new AddToUrlEvent('act=edit&id=' . ModelId::fromModel($model)->getSerialized());
+            $newUrlEvent = new AddToUrlEvent('act=edit&btn=s&id=' . ModelId::fromModel($model)->getSerialized());
             $dispatcher->dispatch($newUrlEvent, ContaoEvents::BACKEND_ADD_TO_URL);
             $dispatcher->dispatch(new RedirectEvent($newUrlEvent->getUrl()), ContaoEvents::CONTROLLER_REDIRECT);
         } elseif ($inputProvider->hasValue('saveNclose')) {
@@ -618,10 +618,11 @@ class EditMask
             $this->clearBackendStates();
             $after = ModelId::fromModel($model);
 
-            $newUrlEvent = new AddToUrlEvent('act=create&id=&after=' . $after->getSerialized());
+            $newUrlEvent = new AddToUrlEvent('act=create&btn=snc&id=&after=' . $after->getSerialized());
             $dispatcher->dispatch($newUrlEvent, ContaoEvents::BACKEND_ADD_TO_URL);
+
             // We have to remove the empty id parameter - see MetaModels/core#1309
-            $url = str_replace('id=&', '', $newUrlEvent->getUrl());
+            $url = \str_replace(['id=&amp;', 'id=&'], '', $newUrlEvent->getUrl());
             $dispatcher->dispatch(new RedirectEvent($url), ContaoEvents::CONTROLLER_REDIRECT);
         } elseif ($inputProvider->hasValue('saveNback')) {
             $this->clearBackendStates();


### PR DESCRIPTION
Fix empty id in URL with new HTLM encoding in Contao 4.9