### PR TITLE
Add grouping by week (replaces #533)

### DIFF
--- a/src/Contao/View/Contao2BackendView/Subscriber/GetGroupHeaderSubscriber.php
+++ b/src/Contao/View/Contao2BackendView/Subscriber/GetGroupHeaderSubscriber.php
@@ -16,6 +16,7 @@
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
  * @copyright  2013-2023 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -202,6 +203,9 @@ class GetGroupHeaderSubscriber
 
             case GroupAndSortingInformationInterface::GROUP_DAY:
                 return $this->formatByDayGrouping((int) $model->getProperty($property->getName()));
+             
+            case GroupAndSortingInformationInterface::GROUP_WEEK:
+                return $this->formatByWeekGrouping((int) $model->getProperty($property->getName()));
 
             case GroupAndSortingInformationInterface::GROUP_MONTH:
                 return $this->formatByMonthGrouping((int) $model->getProperty($property->getName()));
@@ -247,6 +251,26 @@ class GetGroupHeaderSubscriber
         }
 
         $event = new ParseDateEvent($value, Config::get('dateFormat'));
+        $this->dispatcher->dispatch($event, ContaoEvents::DATE_PARSE);
+
+        return $event->getResult();
+    }
+
+    /**
+     * Render a grouping header for week.
+     *
+     * @param int $value The value.
+     *
+     * @return string
+     */
+    private function formatByWeekGrouping($value)
+    {
+        $value = $this->getTimestamp($value);
+
+        if (0 === $value) {
+            return '-';
+        }
+        $event = new ParseDateEvent($value, $this->translator->translate('MSC.week_format'));
         $this->dispatcher->dispatch($event, ContaoEvents::DATE_PARSE);
 
         return $event->getResult();

--- a/src/Contao/View/Contao2BackendView/Subscriber/GetGroupHeaderSubscriber.php
+++ b/src/Contao/View/Contao2BackendView/Subscriber/GetGroupHeaderSubscriber.php
@@ -203,7 +203,7 @@ class GetGroupHeaderSubscriber
 
             case GroupAndSortingInformationInterface::GROUP_DAY:
                 return $this->formatByDayGrouping((int) $model->getProperty($property->getName()));
-             
+
             case GroupAndSortingInformationInterface::GROUP_WEEK:
                 return $this->formatByWeekGrouping((int) $model->getProperty($property->getName()));
 
@@ -263,7 +263,7 @@ class GetGroupHeaderSubscriber
      *
      * @return string
      */
-    private function formatByWeekGrouping($value)
+    private function formatByWeekGrouping(int $value): ?string
     {
         $value = $this->getTimestamp($value);
 

--- a/src/Resources/contao/languages/de/default.php
+++ b/src/Resources/contao/languages/de/default.php
@@ -17,6 +17,7 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
  * @copyright  2013-2023 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -40,4 +41,5 @@ $GLOBALS['TL_LANG']['MSC']['no_properties_available']     = 'Bitte überprüfen 
 $GLOBALS['TL_LANG']['MSC']['select_models']               = 'Elemente auswählen';
 $GLOBALS['TL_LANG']['MSC']['dc_general_disabled']         = 'Gesperrt: %s';
 $GLOBALS['TL_LANG']['MSC']['newRecord']                   = 'Neuen Datensatz erstellen';
+$GLOBALS['TL_LANG']['MSC']['week_format']                 = 'W. Y';
 // @codingStandardsIgnoreEnd

--- a/src/Resources/contao/languages/en/default.php
+++ b/src/Resources/contao/languages/en/default.php
@@ -17,6 +17,7 @@
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     David Molineus <david.molineus@netzmacht.de>
+ * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
  * @copyright  2013-2023 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
@@ -40,4 +41,5 @@ $GLOBALS['TL_LANG']['MSC']['no_properties_available']     = 'Please check your s
 $GLOBALS['TL_LANG']['MSC']['select_models']               = 'Select models';
 $GLOBALS['TL_LANG']['MSC']['dc_general_disabled']         = 'Disabled: %s';
 $GLOBALS['TL_LANG']['MSC']['newRecord']                   = 'Create a new item';
+$GLOBALS['TL_LANG']['MSC']['week_format']                 = 'W Y';
 // @codingStandardsIgnoreEnd


### PR DESCRIPTION
Implements the backend grouping by week

## Description

![screen](https://user-images.githubusercontent.com/1247552/81343544-7aaf2380-90b5-11ea-933d-54fb36b0a8f5.png)

replaces #533

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
