### PR TITLE
Fixed problem with invalid value for offset and amount in session storage

### DIFF
--- a/src/Panel/DefaultLimitElement.php
+++ b/src/Panel/DefaultLimitElement.php
@@ -17,7 +17,8 @@
  * @author     Ingolf Steinhardt <info@e-spin.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     Cliff Parnitzky <github@cliff-parnitzky.de>
- * @copyright  2013-2023 Contao Community Alliance.
+ * @author     Andreas Fischer <anfischer@kaffee-partner.de>
+ * @copyright  2013-2024 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
  * @filesource
  */
@@ -216,8 +217,14 @@ class DefaultLimitElement extends AbstractElement implements LimitElementInterfa
 
         $persistent = $this->getPersistent();
         if ($persistent) {
-            $offset = $persistent['offset'];
-            $amount = $persistent['amount'];
+            if ('all' === $persistent['offset']) {
+                $offset = 0;
+                $amount =  $this->getAmountForFilterOptionAll();
+                $this->setPersistent($offset, $amount);
+            } else {
+                $offset = (int) $persistent['offset'];
+                $amount = (int) $persistent['amount'];
+            }
 
             // Hotfix the offset - we also might want to store it persistent.
             // Another way would be to always stick on the "last" page when we hit the upper limit.


### PR DESCRIPTION
I had a problem with the panel limits when calling a MetaModel backend:
![image](https://github.com/contao-community-alliance/dc-general/assets/2776658/c3255be4-15f6-44b5-a413-ca10b117db1f)

## Description
It turned out that the values read from the session storage were not integer values. I therefore added a corresponding query/validation to prevent a `TypeError`.

## Checklist

- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
