### PR TITLE
Fix tree picker: this prevents crosstalk

### DIFF
--- a/.phpcq.yaml.dist
+++ b/.phpcq.yaml.dist
@@ -56,6 +56,7 @@ phpcq:
     - 31C7E470E2138192
     - 5E6DDE998AB73B8E
     - A978220305CD5C32
+    - 97B02DD8E5071466
     # Composer normalize
     - C00543248C87FB13
     # phpmd

--- a/src/Contao/View/Contao2BackendView/TreePicker.php
+++ b/src/Contao/View/Contao2BackendView/TreePicker.php
@@ -745,7 +745,9 @@ class TreePicker extends Widget
             ->set('providerName', $this->sourceName)
             ->set('readonly', $this->readonly);
 
-        $this->addOrderFieldToTemplate($template);
+        if ('checkbox' === $this->fieldType) {
+            $this->addOrderFieldToTemplate($template);
+        }
 
         return $template->parse();
     }

--- a/src/Contao/View/Contao2BackendView/Widget/FileTree.php
+++ b/src/Contao/View/Contao2BackendView/Widget/FileTree.php
@@ -539,6 +539,10 @@ class FileTree extends AbstractWidget
             // Files can be null.
             if (null !== $files) {
                 foreach ($files as $model) {
+                    if (null === $model || null === $model->uuid) {
+                        continue;
+                    }
+
                     $values[] = StringUtil::binToUuid($model->uuid);
                 }
             }

--- a/src/Contao/View/Contao2BackendView/Widget/FileTree.php
+++ b/src/Contao/View/Contao2BackendView/Widget/FileTree.php
@@ -520,6 +520,8 @@ class FileTree extends AbstractWidget
 
     /**
      * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     public function generate()
     {

--- a/src/Resources/contao/templates/widget_common_picker.html5
+++ b/src/Resources/contao/templates/widget_common_picker.html5
@@ -4,12 +4,16 @@ use Contao\System;
 use Contao\StringUtil;
 
 $requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDefaultTokenValue();
+
+$itemsTitle = '';
 ?>
 <input type="hidden" name="<?= $this->name ?>" id="ctrl_<?= $this->id ?>" value="<?= \implode(',', \array_keys($this->values)) ?>">
 
 <?php $this->block('select-container'); ?>
 <div class="selector_container">
-    <?php if ($this->hasOrder && \count($this->values)): ?>
+    <?php if ($this->hasOrder && \count($this->values)):
+      $itemsTitle = \sprintf(' title="%s"', $this->dragItemsHint);
+      ?>
         <p class="sort_hint">
             <?= $this->dragItemsHint ?>
         </p>
@@ -17,7 +21,7 @@ $requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDef
 
     <ul id="sort_<?= $this->id ?>"<?php if ($this->hasOrder): ?> class="sortable"<?php endif; ?>>
         <?php foreach ($this->values as $k=>$v): ?>
-            <li data-id="<?= $k ?>"><?= $v ?></li>
+            <li data-id="<?= $k ?>"<?= $itemsTitle ?>><?= $v ?></li>
         <?php endforeach; ?>
     </ul>
 </div>

--- a/src/Resources/contao/templates/widget_treepicker.html5
+++ b/src/Resources/contao/templates/widget_treepicker.html5
@@ -2,8 +2,8 @@
 
 <?php if ($this->hasOrder): ?>
     <?php $this->block('multi-source-script'); ?>
-    <input type="hidden" name="<?= $this->orderName ?>" id="ctrl_<?= $this->orderId ?>" value="<?= \implode(',', \array_keys($this->values)) ?>">
-    <script>Backend.makeMultiSrcSortable("sort_<?= $this->id ?>", "ctrl_<?= $this->orderId ?>", "ctrl_<?= $this->id ?>")</script>
+    <input type="hidden" name="<?= $this->orderName ?>" id="ctrl_order_<?= $this->orderId ?>" value="<?= \implode(',', \array_keys($this->values)) ?>">
+    <script>Backend.makeMultiSrcSortable("sort_<?= $this->id ?>", "ctrl_order_<?= $this->orderId ?>", "ctrl_<?= $this->id ?>")</script>
     <?php $this->endblock(); ?>
 <?php endif; ?>
 


### PR DESCRIPTION
Fix tree picker: this prevents crosstalk with fields that have the same name in the mask as in the picker
