### PR TITLE
Revert filetree sortable to write into the order field

### DIFF
--- a/src/Resources/contao/templates/widget_filetree.html5
+++ b/src/Resources/contao/templates/widget_filetree.html5
@@ -48,6 +48,6 @@ $requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDef
         </script>
     <?php endif; ?>
     <?php if ($this->hasOrder): ?>
-        <script>Backend.makeMultiSrcSortable("sort_<?= $this->id ?>", "ctrl_<?= $this->id ?>", "ctrl_<?= $this->id ?>")</script>
+        <script>Backend.makeMultiSrcSortable("sort_<?= $this->id ?>", "ctrl_<?= $this->orderId ?>", "ctrl_<?= $this->id ?>")</script>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
c4929e70 ("Fix sorting files in MCW") pointed makeMultiSrcSortable at the main control instead of the order field, so the dedicated order field (e.g. <name>__sort) was no longer updated on drag & drop. This broke the manual file ordering of the MetaModels file attribute. Restore the order field as sort target, consistent with widget_common_picker/treepicker. The MCW order-id resolution needs a separate, dedicated fix.

