### PR TITLE
Detect the file order field at runtime instead of guessing its id

### DIFF
--- a/src/Resources/contao/templates/widget_filetree.html5
+++ b/src/Resources/contao/templates/widget_filetree.html5
@@ -48,6 +48,17 @@ $requestToken = System::getContainer()->get('contao.csrf.token_manager')->getDef
         </script>
     <?php endif; ?>
     <?php if ($this->hasOrder): ?>
-        <script>Backend.makeMultiSrcSortable("sort_<?= $this->id ?>", "ctrl_<?= $this->orderId ?>", "ctrl_<?= $this->id ?>")</script>
+        <script>
+            // Write the drag & drop order into the dedicated order field (e.g. <name>__sort) when it
+            // is rendered. Inside a MultiColumnWizard row no separate order field exists, so fall back
+            // to the main control there (this is what c4929e70 "Fix sorting files in MCW" did globally,
+            // which broke the standard case). Detecting the field at runtime makes both cases work.
+            (function () {
+                var orderField = document.getElementById("ctrl_<?= $this->orderId ?>")
+                    ? "ctrl_<?= $this->orderId ?>"
+                    : "ctrl_<?= $this->id ?>";
+                Backend.makeMultiSrcSortable("sort_<?= $this->id ?>", orderField, "ctrl_<?= $this->id ?>");
+            })();
+        </script>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
The order id heuristic in FileTree::setUp() (orderField . str_replace(...)) does not resolve to the real order input inside a MultiColumnWizard row, where ids are mangled as <id>_row<n>_<field>. c4929e70 worked around this by always sorting into the main control, which broke the standard case. Detect the dedicated order field in the DOM and fall back to the main control only when it is absent, so both the standard file attribute and MCW rows work.

