### PR TITLE
Fix undefined array key for model locales missing from the enabled Contao locales

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -402,7 +402,11 @@ class DefaultController implements ControllerInterface
             /** @var LanguageInformationInterface $value */
             $locale = $value->getLocale();
 
-            $languages[$locale] = $labels[$locale];
+            // A model may support a locale that is not in the enabled Contao locales (e.g. "en_DE").
+            // Fall back to the ICU display name and finally to the raw locale to avoid an undefined key.
+            $languages[$locale] = $labels[$locale]
+                ?? $intlLocales->getDisplayNames([$locale])[$locale]
+                ?? $locale;
         }
 
         return $languages;


### PR DESCRIPTION
getSupportedLanguages() looked up the locale label directly in Locales::getLocales() (only the enabled locales), which crashed with an "Undefined array key" warning (HTTP 500) when a MetaModel supports a locale that is not enabled system-wide (e.g. "en_DE"). Fall back to the ICU display name (Locales::getDisplayNames) and finally the raw locale. Found via a translated hierarchy model.


