### PR TITLE
Show the record-specific description in operation button tooltips

### DIFF
--- a/src/Contao/View/Contao2BackendView/ButtonRenderer.php
+++ b/src/Contao/View/Contao2BackendView/ButtonRenderer.php
@@ -422,8 +422,24 @@ class ButtonRenderer
             $buttonEvent->getHref() ?? '',
             StringUtil::specialchars($buttonEvent->getTitle()),
             ltrim($buttonEvent->getAttributes()),
-            $this->renderImageAsHtml($icon, $buttonEvent->getLabel())
+            $this->renderImageAsHtml($icon, $this->getButtonImageAlt($buttonEvent))
         );
+    }
+
+    /**
+     * Determine the "alt"/tooltip text for a command button image.
+     *
+     * The Contao tooltip controller reads the image "alt" (selector "a img[alt]"), so we use the full
+     * title/description and fall back to the label when a command has no description (e.g. the
+     * MetaModels child-table operations) - otherwise the tooltip would be empty.
+     *
+     * @param GetOperationButtonEvent $buttonEvent The button event.
+     *
+     * @return string
+     */
+    private function getButtonImageAlt(GetOperationButtonEvent $buttonEvent): string
+    {
+        return $buttonEvent->getTitle() ?: $buttonEvent->getLabel();
     }
 
     /**


### PR DESCRIPTION
Contao's tooltip controller reads the image "alt" attribute (selector "a img[alt]"), not the anchor title. The operation buttons used the short label for the alt, so tooltips showed the generic label (and even leaked the legacy ".0" translation key) instead of the record-specific description.

Use the button title (the modern %id% based description) for the alt, falling back to the label when a command has no description (e.g. the MetaModels child-table operations) so those tooltips are not empty. The alt computation is extracted into getButtonImageAlt().
