### PR TITLE
Harden the legacy .0/.1 translation fallback against key leaks

### DIFF
--- a/src/Contao/View/Contao2BackendView/ActionHandler/AbstractListShowAllHandler.php
+++ b/src/Contao/View/Contao2BackendView/ActionHandler/AbstractListShowAllHandler.php
@@ -405,7 +405,16 @@ abstract class AbstractListShowAllHandler
             return $header;
         }
 
-        return $this->translate($buttonName . '.0', $definitionName, $parameter);
+        // Legacy fallback to the old array based translation (element 0).
+        // @deprecated Remove in 3.0 - migrate to the symfony translator with named parameters.
+        if (
+            $buttonName . '.0' !== ($header = $this->translate($buttonName . '.0', $definitionName, $parameter))
+        ) {
+            return $header;
+        }
+
+        // The label is already a plain (translated) string and not a translation key.
+        return $buttonName;
     }
 
     protected function translateButtonDescription(
@@ -421,7 +430,16 @@ abstract class AbstractListShowAllHandler
             return $header;
         }
 
-        return $this->translate($buttonName . '.1', $definitionName, $parameter);
+        // Legacy fallback to the old array based translation (element 1).
+        // @deprecated Remove in 3.0 - migrate to the symfony translator with named parameters.
+        if (
+            $buttonName . '.1' !== ($header = $this->translate($buttonName . '.1', $definitionName, $parameter))
+        ) {
+            return $header;
+        }
+
+        // The description is already a plain (translated) string and not a translation key.
+        return $buttonName;
     }
 
     /**

--- a/src/Contao/View/Contao2BackendView/ButtonRenderer.php
+++ b/src/Contao/View/Contao2BackendView/ButtonRenderer.php
@@ -653,7 +653,17 @@ class ButtonRenderer
             return $header;
         }
 
-        return $this->translator->translate($buttonName . '.0', $definitionName, $parameter);
+        // Legacy fallback to the old array based translation (element 0).
+        // @deprecated Remove in 3.0 - migrate to the symfony translator with named parameters.
+        if (
+            $buttonName . '.0' !== ($header =
+                $this->translator->translate($buttonName . '.0', $definitionName, $parameter))
+        ) {
+            return $header;
+        }
+
+        // The label is already a plain (translated) string and not a translation key.
+        return $buttonName;
     }
 
     protected function translateButtonDescription(


### PR DESCRIPTION
translateButtonLabel()/translateButtonDescription() in ButtonRenderer and AbstractListShowAllHandler returned the untranslated "<name>.0"/".1" key when neither the modern (.label/.description) nor the legacy (.0/.1) translation existed - e.g. when a plain, already translated string was passed. Fall back to the string itself, consistent with GlobalButtonRenderer. The legacy .0/.1 paths stay a 3.0 removal candidate (see docs/3.0-cleanup-tasks.md).
