### PR TITLE
Log create/duplicate/delete to the Contao system log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "doctrine/dbal": "^3.7 || ^4.3",
     "knplabs/knp-menu": "^3.1",
     "psr/event-dispatcher": "^1.0",
+    "psr/log": "^3.0",
     "symfony/cache": "^7.4",
     "symfony/cache-contracts": "^3.0",
     "symfony/config": "^7.4",

--- a/src/DataDefinition/DataProviderInformation.php
+++ b/src/DataDefinition/DataProviderInformation.php
@@ -23,7 +23,7 @@ namespace ContaoCommunityAlliance\DcGeneral\DataDefinition;
 /**
  * A generic data provider information.
  */
-class DataProviderInformation implements DataProviderInformationInterface
+class DataProviderInformation implements DataProviderInformationInterface, LoggingInformationInterface
 {
     /**
      * The name of the data provider information.
@@ -38,6 +38,16 @@ class DataProviderInformation implements DataProviderInformationInterface
      * @var bool
      */
     protected $versioningEnabled = false;
+
+    /**
+     * Flag determining if create/duplicate/delete are logged for this provider or not.
+     *
+     * Defaults to enabled - this mirrors what Contao logs for its own tables, an unconfigured
+     * provider should not silently lose that.
+     *
+     * @var bool
+     */
+    protected bool $loggingEnabled = true;
 
     /**
      * {@inheritdoc}
@@ -77,5 +87,25 @@ class DataProviderInformation implements DataProviderInformationInterface
     public function isVersioningEnabled()
     {
         return $this->versioningEnabled;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    #[\Override]
+    public function setLoggingEnabled(bool $loggingEnabled): self
+    {
+        $this->loggingEnabled = $loggingEnabled;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    #[\Override]
+    public function isLoggingEnabled(): bool
+    {
+        return $this->loggingEnabled;
     }
 }

--- a/src/DataDefinition/LoggingInformationInterface.php
+++ b/src/DataDefinition/LoggingInformationInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2026 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2013-2026 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+declare(strict_types=1);
+
+namespace ContaoCommunityAlliance\DcGeneral\DataDefinition;
+
+/**
+ * Whether create/duplicate/delete on this data provider are written to the Contao system log
+ * (tl_log). A separate interface rather than an addition to DataProviderInformationInterface,
+ * which would break every existing implementation - see ".claude/dcg-systemlog.md". A data
+ * provider information that does not implement this interface counts as "not configured", which
+ * is treated the same as enabled - logging mirrors what Contao already does for its own tables, so
+ * an unconfigured provider should not silently lose that.
+ */
+interface LoggingInformationInterface
+{
+    /**
+     * Determine if the create/duplicate/delete of a record shall be logged.
+     *
+     * @return bool
+     */
+    public function isLoggingEnabled(): bool;
+
+    /**
+     * Set if the create/duplicate/delete of a record shall be logged.
+     *
+     * @param bool $loggingEnabled The flag.
+     *
+     * @return $this
+     */
+    public function setLoggingEnabled(bool $loggingEnabled): self;
+}

--- a/src/EventListener/LogPersistedModelsListener.php
+++ b/src/EventListener/LogPersistedModelsListener.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2026 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2013-2026 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+declare(strict_types=1);
+
+namespace ContaoCommunityAlliance\DcGeneral\EventListener;
+
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\ContainerInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\LoggingInformationInterface;
+use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
+use ContaoCommunityAlliance\DcGeneral\Event\PostDeleteModelEvent;
+use ContaoCommunityAlliance\DcGeneral\Event\PostDuplicateModelEvent;
+use ContaoCommunityAlliance\DcGeneral\Event\PostPersistModelEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Mirrors what Contao's own DC_Table logs for its tables into the Contao system log (tl_log) for
+ * DC_General-driven tables, which so far never logged anything - see ".claude/dcg-systemlog.md".
+ *
+ * Deliberately covers create, duplicate and delete only, matching what Contao itself logs for its
+ * own tables. Two things that might look missing are excluded on purpose, not overlooked:
+ *
+ * - Editing an existing record. Contao does not log edits either - that is what versioning is for.
+ * - Toggling a boolean field (publish state and the like). It fires the very same
+ *   PostPersistModelEvent as a normal edit, with the same non-null original model, and is
+ *   therefore structurally indistinguishable from it without a property-by-property diff Contao
+ *   itself does not do either - so it stays out for the same reason a normal edit does.
+ *
+ * @api
+ */
+class LogPersistedModelsListener
+{
+    /**
+     * Create a new instance.
+     *
+     * @param LoggerInterface $logger The "contao.general" channel logger.
+     */
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    /**
+     * Log the creation of a new record.
+     *
+     * @param PostPersistModelEvent $event The event.
+     *
+     * @return void
+     */
+    public function onPersist(PostPersistModelEvent $event): void
+    {
+        // Edits fire this same event with the previously stored data as original model. A create
+        // is not signalled by a null original model - CreateHandler passes an empty one
+        // (getEmptyModel()), never a literal null, regardless of what the event's own docblock
+        // says - it has no id yet, which is what actually tells the two apart.
+        $originalModel = $event->getOriginalModel();
+        if (null !== $originalModel && null !== $originalModel->getId()) {
+            return;
+        }
+
+        $model = $event->getModel();
+        if (!$this->isLoggingEnabled($event->getEnvironment(), $model)) {
+            return;
+        }
+
+        $this->logger->info(
+            \sprintf('A new entry "%s.id=%s" has been created', $model->getProviderName(), (string) $model->getId())
+        );
+    }
+
+    /**
+     * Log the creation of a record by duplicating another one.
+     *
+     * @param PostDuplicateModelEvent $event The event.
+     *
+     * @return void
+     */
+    public function onDuplicate(PostDuplicateModelEvent $event): void
+    {
+        $model = $event->getModel();
+        if (!$this->isLoggingEnabled($event->getEnvironment(), $model)) {
+            return;
+        }
+
+        $source = $event->getSourceModel();
+        $this->logger->info(
+            \sprintf(
+                'A new entry "%s.id=%s" has been created by duplicating record "%s.id=%s"',
+                $model->getProviderName(),
+                (string) $model->getId(),
+                $source->getProviderName(),
+                (string) $source->getId()
+            )
+        );
+    }
+
+    /**
+     * Log the deletion of a record.
+     *
+     * @param PostDeleteModelEvent $event The event.
+     *
+     * @return void
+     */
+    public function onDelete(PostDeleteModelEvent $event): void
+    {
+        $model = $event->getModel();
+        if (!$this->isLoggingEnabled($event->getEnvironment(), $model)) {
+            return;
+        }
+
+        $this->logger->info(
+            \sprintf('DELETE FROM %s WHERE id=%s', $model->getProviderName(), (string) $model->getId())
+        );
+    }
+
+    /**
+     * Determine if logging is enabled for the data provider the given model belongs to.
+     *
+     * A provider information that does not implement LoggingInformationInterface at all - either
+     * a foreign DataProviderInformationInterface implementation, or none registered yet - counts
+     * as "not configured", which is treated the same as enabled.
+     *
+     * @param EnvironmentInterface $environment The environment.
+     * @param ModelInterface       $model       The model.
+     *
+     * @return bool
+     */
+    private function isLoggingEnabled(EnvironmentInterface $environment, ModelInterface $model): bool
+    {
+        $definition = $environment->getDataDefinition();
+        if (!$definition instanceof ContainerInterface) {
+            return true;
+        }
+
+        $providerDefinition = $definition->getDataProviderDefinition();
+        if (!$providerDefinition->hasInformation($model->getProviderName())) {
+            return true;
+        }
+
+        $information = $providerDefinition->getInformation($model->getProviderName());
+        if (!$information instanceof LoggingInformationInterface) {
+            return true;
+        }
+
+        return $information->isLoggingEnabled();
+    }
+}

--- a/src/Resources/config/event_listeners.yml
+++ b/src/Resources/config/event_listeners.yml
@@ -15,6 +15,22 @@ services:
                 event: dc-general.model.enforce-relationship
                 method: process
 
+    cca.dc-general.general_listener.log_persisted_models:
+        class: ContaoCommunityAlliance\DcGeneral\EventListener\LogPersistedModelsListener
+        public: true
+        arguments:
+            - '@monolog.logger.contao.general'
+        tags:
+            -   name: kernel.event_listener
+                event: dc-general.model.post-persist
+                method: onPersist
+            -   name: kernel.event_listener
+                event: dc-general.model.post-duplicate
+                method: onDuplicate
+            -   name: kernel.event_listener
+                event: dc-general.model.post-delete
+                method: onDelete
+
     cca.dc-general.general_listener.select_mode_buttons:
         class: ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EventListener\SelectModeButtonsListener
         public: true

--- a/tests/EventListener/LogPersistedModelsListenerTest.php
+++ b/tests/EventListener/LogPersistedModelsListenerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2026 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2013-2026 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+declare(strict_types=1);
+
+namespace ContaoCommunityAlliance\DcGeneral\Test\EventListener;
+
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\ContainerInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\DataProviderInformationInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\Definition\DataProviderDefinitionInterface;
+use ContaoCommunityAlliance\DcGeneral\DataDefinition\LoggingInformationInterface;
+use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
+use ContaoCommunityAlliance\DcGeneral\Event\PostDeleteModelEvent;
+use ContaoCommunityAlliance\DcGeneral\Event\PostDuplicateModelEvent;
+use ContaoCommunityAlliance\DcGeneral\Event\PostPersistModelEvent;
+use ContaoCommunityAlliance\DcGeneral\EventListener\LogPersistedModelsListener;
+use ContaoCommunityAlliance\DcGeneral\Test\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for LogPersistedModelsListener - see ".claude/dcg-systemlog.md" for the background.
+ */
+#[CoversClass(LogPersistedModelsListener::class)]
+class LogPersistedModelsListenerTest extends TestCase
+{
+    private function mockModel(string $providerName, string $id): ModelInterface
+    {
+        $model = $this->createMock(ModelInterface::class);
+        $model->method('getProviderName')->willReturn($providerName);
+        $model->method('getId')->willReturn($id);
+
+        return $model;
+    }
+
+    /**
+     * What CreateHandler actually passes as the original model on a create -
+     * DataProviderInterface::getEmptyModel(), not a literal null.
+     */
+    private function mockEmptyModel(): ModelInterface
+    {
+        $model = $this->createMock(ModelInterface::class);
+        $model->method('getId')->willReturn(null);
+
+        return $model;
+    }
+
+    /**
+     * @param bool|null $loggingEnabled Null = the provider information does not implement
+     *                                  LoggingInformationInterface at all ("not configured").
+     */
+    private function mockEnvironment(string $providerName, ?bool $loggingEnabled): EnvironmentInterface
+    {
+        if (null === $loggingEnabled) {
+            $information = $this->createMock(DataProviderInformationInterface::class);
+        } else {
+            $information = $this->createMockForIntersectionOfInterfaces(
+                [DataProviderInformationInterface::class, LoggingInformationInterface::class]
+            );
+            $information->method('isLoggingEnabled')->willReturn($loggingEnabled);
+        }
+
+        $providerDefinition = $this->createMock(DataProviderDefinitionInterface::class);
+        $providerDefinition->method('hasInformation')->with($providerName)->willReturn(true);
+        $providerDefinition->method('getInformation')->with($providerName)->willReturn($information);
+
+        $definition = $this->createMock(ContainerInterface::class);
+        $definition->method('getDataProviderDefinition')->willReturn($providerDefinition);
+
+        $environment = $this->createMock(EnvironmentInterface::class);
+        $environment->method('getDataDefinition')->willReturn($definition);
+
+        return $environment;
+    }
+
+    public function testLogsTheCreationOfANewRecord(): void
+    {
+        $model       = $this->mockModel('tl_test', '5');
+        $environment = $this->mockEnvironment('tl_test', true);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with('A new entry "tl_test.id=5" has been created');
+
+        (new LogPersistedModelsListener($logger))->onPersist(new PostPersistModelEvent($environment, $model, null));
+    }
+
+    public function testLogsTheCreationOfANewRecordWhenTheOriginalModelIsAnEmptyPlaceholder(): void
+    {
+        // The real path (CreateHandler): the original model is never a literal null, only unset.
+        $model       = $this->mockModel('tl_test', '5');
+        $environment = $this->mockEnvironment('tl_test', true);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with('A new entry "tl_test.id=5" has been created');
+
+        (new LogPersistedModelsListener($logger))
+            ->onPersist(new PostPersistModelEvent($environment, $model, $this->mockEmptyModel()));
+    }
+
+    public function testDoesNotLogAnEditOfAnExistingRecord(): void
+    {
+        $model         = $this->mockModel('tl_test', '5');
+        $originalModel = $this->mockModel('tl_test', '5');
+        $environment   = $this->mockEnvironment('tl_test', true);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+
+        (new LogPersistedModelsListener($logger))
+            ->onPersist(new PostPersistModelEvent($environment, $model, $originalModel));
+    }
+
+    public function testLogsDuplicationWithBothIds(): void
+    {
+        $model       = $this->mockModel('tl_test', '9');
+        $source      = $this->mockModel('tl_test', '5');
+        $environment = $this->mockEnvironment('tl_test', true);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('info')
+            ->with('A new entry "tl_test.id=9" has been created by duplicating record "tl_test.id=5"');
+
+        (new LogPersistedModelsListener($logger))
+            ->onDuplicate(new PostDuplicateModelEvent($environment, $model, $source));
+    }
+
+    public function testLogsDeletion(): void
+    {
+        $model       = $this->mockModel('tl_test', '5');
+        $environment = $this->mockEnvironment('tl_test', true);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with('DELETE FROM tl_test WHERE id=5');
+
+        (new LogPersistedModelsListener($logger))->onDelete(new PostDeleteModelEvent($environment, $model));
+    }
+
+    public function testStaysSilentWhenLoggingIsDisabledForTheProvider(): void
+    {
+        $model       = $this->mockModel('tl_test', '5');
+        $environment = $this->mockEnvironment('tl_test', false);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+
+        (new LogPersistedModelsListener($logger))->onDelete(new PostDeleteModelEvent($environment, $model));
+    }
+
+    public function testLogsWhenTheProviderInformationDoesNotImplementTheLoggingInterface(): void
+    {
+        // "Not configured" counts as enabled - a foreign DataProviderInformationInterface
+        // implementation must not silently lose logging Contao's own tables always had.
+        $model       = $this->mockModel('tl_test', '5');
+        $environment = $this->mockEnvironment('tl_test', null);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info');
+
+        (new LogPersistedModelsListener($logger))->onDelete(new PostDeleteModelEvent($environment, $model));
+    }
+}


### PR DESCRIPTION
DC_General never wrote anything to tl_log, unlike Contao's own DC_Table, which logs the same three operations (edit is deliberately left out - Contao doesn't log that either, versioning covers it, and toggling a field fires the very same event as an edit with no way to tell them apart).

New LoggingInformationInterface, additive to
DataProviderInformationInterface so no foreign implementation breaks - a provider information not implementing it counts as "not configured", same as enabled. DataProviderInformation implements it, default on.

LogPersistedModelsListener writes the same wording DC_Table already uses, through the "contao.general" monolog channel like Contao itself does. psr/log was missing from composer.json, added.

CreateHandler passes an empty model (getEmptyModel()) as the original model on create, never a literal null despite what PostPersistModelEvent's own docblock claims - checking for that empty model's id is what actually tells a create from an edit apart.
