### PR TITLE
Show the version comparison popup for both the edit mask and the list view

### DIFF
--- a/src/Contao/View/Contao2BackendView/ActionHandler/EditHandler.php
+++ b/src/Contao/View/Contao2BackendView/ActionHandler/EditHandler.php
@@ -22,6 +22,7 @@
 
 namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\ActionHandler;
 
+use Contao\Versions;
 use ContaoCommunityAlliance\Contao\Bindings\ContaoEvents;
 use ContaoCommunityAlliance\Contao\Bindings\Events\Controller\ReloadEvent;
 use ContaoCommunityAlliance\Contao\Bindings\Events\System\LogEvent;
@@ -134,6 +135,7 @@ class EditHandler
             return false;
         }
 
+        $this->checkCompareVersion($environment, $modelId);
         $this->checkRestoreVersion($environment, $modelId);
 
         if (!($model = $dataProvider->fetch($dataProvider->getEmptyConfig()->setId($modelId->getId())))) {
@@ -228,6 +230,42 @@ class EditHandler
         );
 
         return false;
+    }
+
+    /**
+     * Check whether the "compare two versions" popup (the diff-icon next to the version dropdown
+     * on the edit mask) was requested and, if so, render it.
+     *
+     * Mirrors the "if (Input::get('versions')) { $objVersions->compare(); }" branch in
+     * Contao\DC_Table::edit() - the diff view itself (Contao\Versions::compare()) works purely off
+     * the table name and record id against tl_version, with no DC_Table-specific coupling, so the
+     * same call works unchanged for a dc-general table. compare() throws a ResponseException to
+     * short-circuit the request with the popup content, which is why this method has nothing to
+     * return: it either does that or does nothing at all.
+     *
+     * @param EnvironmentInterface $environment The environment.
+     * @param ModelIdInterface     $modelId     The model id.
+     *
+     * @return void
+     */
+    private function checkCompareVersion(EnvironmentInterface $environment, ModelIdInterface $modelId)
+    {
+        $inputProvider = $environment->getInputProvider();
+        assert($inputProvider instanceof InputProviderInterface);
+
+        $dataDefinition = $environment->getDataDefinition();
+        assert($dataDefinition instanceof ContainerInterface);
+
+        if (
+            !$inputProvider->getParameter('versions')
+            || !$dataDefinition->getDataProviderDefinition()
+                ->getInformation($modelId->getDataProviderName())
+                ->isVersioningEnabled()
+        ) {
+            return;
+        }
+
+        (new Versions($modelId->getDataProviderName(), (int) $modelId->getId()))->compare();
     }
 
     /**

--- a/src/Contao/View/Contao2BackendView/EventListener/DiffButtonListener.php
+++ b/src/Contao/View/Contao2BackendView/EventListener/DiffButtonListener.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/dc-general.
+ *
+ * (c) 2013-2026 Contao Community Alliance.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/dc-general
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2013-2026 Contao Community Alliance.
+ * @license    https://github.com/contao-community-alliance/dc-general/blob/master/LICENSE LGPL-3.0-or-later
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EventListener;
+
+use Contao\StringUtil;
+use Contao\System;
+use ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\Event\GetOperationButtonEvent;
+use ContaoCommunityAlliance\DcGeneral\Data\ModelInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * This opens the version comparison as a modal iframe for the "versions" operation button.
+ *
+ * Contao core injects a "versions" list operation for every table with "enableVersioning" via
+ * Contao\CoreBundle\EventListener\DataContainer\DefaultOperationsListener, including a modern
+ * "button_callback" closure that sets the "onclick" attribute opening the diff popup. dc-general's
+ * legacy DCA-to-Command translation reads the static operation keys (href, icon, ...) but never
+ * invokes that callback, so the button rendered without it - the icon was there but nothing opened.
+ *
+ * @api
+ */
+class DiffButtonListener
+{
+    /**
+     * Handle the event.
+     *
+     * @param GetOperationButtonEvent $event The event.
+     *
+     * @return void
+     */
+    public function handle(GetOperationButtonEvent $event)
+    {
+        if ('versions' !== $event->getKey()) {
+            return;
+        }
+
+        $model = $event->getModel();
+        if (!$model instanceof ModelInterface) {
+            return;
+        }
+
+        $translator = System::getContainer()->get('translator');
+        assert($translator instanceof TranslatorInterface);
+
+        $title = StringUtil::specialchars(
+            \str_replace(
+                "'",
+                "\\'",
+                $translator->trans(
+                    'MSC.recordOfTable',
+                    [$model->getId(), $model->getProviderName()],
+                    'contao_default'
+                )
+            )
+        );
+
+        $onclick = 'onclick="Backend.openModalIframe({title:\'' . $title . '\', '
+            . 'url:this.href+\'&popup=1&nb=1\'});return false"';
+
+        $event->setAttributes(\trim($event->getAttributes() . ' ' . $onclick));
+    }
+}

--- a/src/Resources/config/contao/button_backend_listeners.yml
+++ b/src/Resources/config/contao/button_backend_listeners.yml
@@ -1,4 +1,12 @@
 services:
+    cca.dc-general.backend_listener.diff_button_listener:
+        class: ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EventListener\DiffButtonListener
+        public: true
+        tags:
+            -   name: kernel.event_listener
+                event: dc-general.view.contao2backend.get-operation-button
+                method: handle
+
     cca.dc-general.backend_listener.backend_button_listener:
         class: ContaoCommunityAlliance\DcGeneral\Contao\View\Contao2BackendView\EventListener\BackButtonListener
         public: true

--- a/src/Resources/contao/templates/dcbe_general_edit.html5
+++ b/src/Resources/contao/templates/dcbe_general_edit.html5
@@ -1,6 +1,8 @@
 <?php
 
 use ContaoCommunityAlliance\DcGeneral\Data\VersionModelInterface;
+use Contao\Backend;
+use Contao\Image;
 use Contao\Message;
 use Contao\StringUtil;
 use Contao\System;
@@ -59,6 +61,20 @@ $hasLanguageSwitcher = $this->language && !empty($this->languages);
                     </option>
                 <?php endforeach; ?>
                 </select> <input type="submit" name="showVersion" id="showVersion" class="tl_submit" value="<?= StringUtil::specialchars($translator->trans(id: 'restore', domain: 'dc-general')) ?>" />
+                <?php
+                // Contao's own version panel (Contao\Versions::renderDropdown()) adds this same
+                // diff-icon link next to the restore button, opening a modal iframe that compares
+                // two versions (act=showVersion&popup=1). This template builds the panel from
+                // scratch rather than calling that method, and had never included it.
+                $diffTitle = StringUtil::specialchars(
+                    str_replace(
+                        "'",
+                        "\\'",
+                        $translator->trans('MSC.recordOfTable', [$this->model->getId(), $this->table], 'contao_default')
+                    )
+                );
+                ?>
+                <a href="<?= Backend::addToUrl('versions=1&amp;popup=1') ?>" onclick="Backend.openModalIframe({'title':'<?= $diffTitle ?>','url':this.href});return false"><?= Image::getHtml('diff.svg', $translator->trans('MSC.showDifferences', [], 'contao_default')) ?></a>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary

- Contao's own edit mask shows a diff icon next to the "Wiederherstellen" button that opens a popup comparing two versions. The classic `dcbe_general_edit.html5` template never had this link; add it and handle the resulting `versions=1` request the same way `Contao\DC_Table::edit()` does.
- The list view's "versions" operation button had the opposite problem: the icon was there, but clicking it did nothing. Contao core injects that button via a `#[AsHook('loadDataContainer')]` listener whose modern `button_callback` sets the missing `onclick` attribute - a callback style dc-general's legacy DCA-to-Command translation never invokes. Add a `DiffButtonListener` on `GetOperationButtonEvent` that sets the same attribute for any table's "versions" command.

## Test plan

- [x] Edit mask: clicking the diff icon next to "Wiederherstellen" opens the version comparison popup (verified via Playwright screenshot)
- [x] List view: clicking the "versions" operation icon now opens the same popup with the version diff table (verified via Playwright)