### PR TITLE
Handle a missing file resource in the file tree ajax reload

### DIFF
--- a/src/Controller/Ajax3X.php
+++ b/src/Controller/Ajax3X.php
@@ -40,11 +40,16 @@ use ContaoCommunityAlliance\DcGeneral\DataDefinition\ContainerInterface;
 use ContaoCommunityAlliance\DcGeneral\EnvironmentInterface;
 use ContaoCommunityAlliance\DcGeneral\InputProviderInterface;
 use ContaoCommunityAlliance\DcGeneral\SessionStorageInterface;
+use ContaoCommunityAlliance\Translator\TranslatorInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 
+use function array_map;
+use function htmlspecialchars;
 use function implode;
 use function is_string;
+use function json_encode;
+use function sprintf;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
@@ -120,6 +125,8 @@ class Ajax3X extends Ajax
      * @param string $value The value as comma separated list.
      *
      * @return list<string> The value array.
+     *
+     * @throws ResponseException Throws a response exception if a selected file no longer exists on disk.
      */
     protected function getTreeValue($type, $value)
     {
@@ -132,14 +139,86 @@ class Ajax3X extends Ajax
 
         // Automatically add resources to the DBAFS.
         if ('file' === $type) {
+            $invalidResources = [];
             foreach ($value as $k => $v) {
-                $uuid = Dbafs::addResource(urldecode($v))->uuid;
+                $resource = urldecode($v);
+                try {
+                    $uuid = Dbafs::addResource($resource)->uuid;
+                } catch (\InvalidArgumentException) {
+                    // The file has been removed from the file system directly without a DBAFS sync - report it
+                    // instead of letting the exception bubble up as an uncaught 500 (see #101).
+                    $invalidResources[] = $resource;
+                    continue;
+                }
                 assert(is_string($uuid));
                 $value[$k] = StringUtil::binToUuid($uuid);
+            }
+
+            if ([] !== $invalidResources) {
+                $this->logInvalidFileResources($invalidResources);
+
+                throw new ResponseException($this->buildInvalidFileResourceResponse($invalidResources));
             }
         }
 
         return array_map('strval', $value);
+    }
+
+    /**
+     * Log that one or more selected files no longer exist on disk.
+     *
+     * @param list<string> $invalidResources The resource paths that could not be added to the DBAFS.
+     *
+     * @return void
+     */
+    private function logInvalidFileResources(array $invalidResources): void
+    {
+        $environment = $this->getEnvironment();
+        assert($environment instanceof EnvironmentInterface);
+
+        $event = new LogEvent(
+            'The following file(s) no longer exist on disk and could not be added to the DBAFS: ' .
+            implode(', ', $invalidResources),
+            'Ajax executePostActions()',
+            'ERROR'
+        );
+
+        $dispatcher = $environment->getEventDispatcher();
+        assert($dispatcher instanceof EventDispatcherInterface);
+
+        $dispatcher->dispatch($event, ContaoEvents::SYSTEM_LOG);
+    }
+
+    /**
+     * Build a friendly ajax response informing the editor that one or more files no longer exist on disk.
+     *
+     * @param list<string> $invalidResources The resource paths that could not be added to the DBAFS.
+     *
+     * @return Response
+     */
+    private function buildInvalidFileResourceResponse(array $invalidResources): Response
+    {
+        $environment = $this->getEnvironment();
+        assert($environment instanceof EnvironmentInterface);
+
+        $translator = $environment->getTranslator();
+        assert($translator instanceof TranslatorInterface);
+
+        $message = $translator->translate(
+            'exception.invalid_file_resource',
+            'dc-general',
+            ['%resources%' => implode(', ', $invalidResources)]
+        );
+
+        $content = sprintf(
+            '<div><p class="tl_error">%s</p></div>',
+            htmlspecialchars($message, ENT_QUOTES)
+        );
+
+        $response = new Response((string) json_encode(['content' => $content]));
+        $response->headers->set('Content-Type', 'application/json');
+
+        return $response;
     }
 
     /**

--- a/src/Resources/translations/dc-general.de.xlf
+++ b/src/Resources/translations/dc-general.de.xlf
@@ -545,5 +545,11 @@
         <target>Diese Ansicht unterstützt nur das Bearbeiten vorhandener Datensätze.</target>
       </segment>
     </unit>
+    <unit id="exception.invalid_file_resource" name="exception.invalid_file_resource">
+      <segment>
+        <source>The following file(s) no longer exist on disk: %resources%. Please synchronise the file system in the file manager.</source>
+        <target>Folgende Datei(en) sind im Dateisystem nicht mehr vorhanden: %resources%. Bitte im Dateimanager synchronisieren.</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/src/Resources/translations/dc-general.en.xlf
+++ b/src/Resources/translations/dc-general.en.xlf
@@ -452,5 +452,10 @@
         <source>This view only supports editing existing records.</source>
       </segment>
     </unit>
+    <unit id="exception.invalid_file_resource" name="exception.invalid_file_resource">
+      <segment>
+        <source>The following file(s) no longer exist on disk: %resources%. Please synchronise the file system in the file manager.</source>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary
- `Ajax3X::getTreeValue()` called `Dbafs::addResource()` for every selected file without catching the `InvalidArgumentException` it throws when the resource no longer exists on disk (e.g. deleted directly in the file system without a DBAFS sync).
- The exception went uncaught and surfaced as a raw 500 to the editor, with no indication of what went wrong or how to fix it.
- Now the exception is caught, the offending resource(s) are logged to the system log, and the ajax response carries a translated error message ("... no longer exist on disk ... please synchronise the file system in the file manager") that lands in the widget via the existing `DcGeneral.setHtml()` pipeline.
- Adds the `exception.invalid_file_resource` translation key (de/en).

Fixes MetaModels/attribute_file#101

## Test plan
- [x] `php -l` on the changed file
- [x] `phpcq.py check contao-community-alliance/dc-general` — no findings
- [x] Verified against a running Contao 5.7 backend: selected a file, deleted it directly on disk (DBAFS not synced), then POSTed the same `reloadFiletree` ajax action the widget sends — response is now `200 application/json` with the friendly error message instead of an uncaught 500, and the incident appears in `tl_log`